### PR TITLE
Explicit begin...commit statements in resulting diff file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+                v1.0.10
+
+                Features:
+                    - Explicit begin...commit in resulting diff file
+
 2026-03-27      v1.0.9
 
                 Features:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Command line arguments can be used to execute just one function in one time.
 
 `--use-drop` - specify this argument if you want to use DROPs in output script, otherwise no DROPs will be used.
 
+`--use-single-transaction` - use this flag to wrap resulting diff file within explicit `begin;` and `commit;` statements (i.e. single transaction).
+
 ## Functionality
 
 ### Create database schema dump
@@ -115,4 +117,5 @@ OUTPUT=delta.sql
 
 # ADDITIONAL PROPERTIES
 USE_DROP=true
+USE_SINGLE_TRANSACTION=true
 ```

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgc"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "chrono",
  "clap",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgc"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2024"
 license = "MIT"
 

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -14,6 +14,8 @@ pub struct Comparer {
     to: Dump,
     // Whether to use DROP statements in the output
     use_drop: bool,
+    // True - if explicit begin...commit statement has to be added; False - otherwise
+    use_single_transaction: bool,
 
     // The script that will be generated
     script: String,
@@ -30,11 +32,12 @@ pub struct Comparer {
 
 impl Comparer {
     // Creates a new Comparer with the given dumps
-    pub fn new(from: Dump, to: Dump, use_drop: bool) -> Self {
+    pub fn new(from: Dump, to: Dump, use_drop: bool, use_single_transaction: bool) -> Self {
         let mut comparer = Self {
             from,
             to,
             use_drop,
+            use_single_transaction,
             script: String::new(),
             enum_pre_script: String::new(),
             enum_post_script: String::new(),
@@ -64,6 +67,10 @@ impl Comparer {
 
     // Compare dumps and generate the script
     pub async fn compare(&mut self) -> Result<(), Error> {
+        if self.use_single_transaction {
+            self.script.push_str("begin;\n\n");
+        }
+
         self.compare_schemas().await?;
         self.compare_extensions().await?;
         self.compare_enums().await?;
@@ -98,6 +105,10 @@ impl Comparer {
         if !self.trigger_post_script.is_empty() {
             self.script.push_str(&self.trigger_post_script);
             self.trigger_post_script.clear();
+        }
+
+        if self.use_single_transaction {
+            self.script.push_str("\ncommit;");
         }
 
         Ok(())
@@ -2022,7 +2033,7 @@ mod tests {
         from_dump.routines.push(from_routine);
         to_dump.routines.push(to_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2066,7 +2077,7 @@ mod tests {
         from_dump.routines.push(from_routine);
         to_dump.routines.push(to_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2111,7 +2122,7 @@ mod tests {
         to_dump.routines.push(sql_routine);
         to_dump.routines.push(plpgsql_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2147,7 +2158,7 @@ mod tests {
         );
         from_dump.routines.push(dropped_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -2191,7 +2202,7 @@ mod tests {
         );
         from_dump.routines.push(dropped_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -2229,7 +2240,7 @@ mod tests {
             vec![("street", "varchar(255)"), ("city", "varchar(100)")],
         ));
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -2255,7 +2266,7 @@ mod tests {
         from_dump.schemas.push(from_schema);
         to_dump.schemas.push(to_schema);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_schemas().await.unwrap();
         let script = comparer.get_script();
 
@@ -2284,7 +2295,7 @@ mod tests {
         from_dump.extensions.push(from_ext);
         to_dump.extensions.push(to_ext);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_extensions().await.unwrap();
         let script = comparer.get_script();
 
@@ -2331,7 +2342,7 @@ mod tests {
         from_dump.routines.push(from_routine);
         to_dump.routines.push(to_routine);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2407,7 +2418,7 @@ mod tests {
         to_dump.routines.push(a_middle);
         to_dump.routines.push(r_base);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2493,7 +2504,7 @@ mod tests {
         from_dump.routines.push(x_step);
         from_dump.routines.push(a_middle);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_routines().await.unwrap();
         let script = comparer.get_script();
 
@@ -2581,7 +2592,7 @@ mod tests {
         to_dump.routines.push(a_middle);
         to_dump.routines.push(r_base);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_routines_and_views().await.unwrap();
         let script = comparer.get_script();
 
@@ -2762,7 +2773,7 @@ mod tests {
         );
         to_dump.tables.push(table);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -2860,7 +2871,7 @@ mod tests {
         );
         to_dump.tables.push(table);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -2894,7 +2905,7 @@ mod tests {
         );
         to_dump.sequences.push(sequence);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -2944,7 +2955,7 @@ mod tests {
         from_dump.sequences.push(from_sequence);
         to_dump.sequences.push(to_sequence);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -3039,7 +3050,7 @@ mod tests {
         );
         from_dump.tables.push(table);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -3200,7 +3211,7 @@ mod tests {
         );
         to_dump.tables.push(to_table);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_sequences().await.unwrap();
         let script = comparer.get_script();
 
@@ -3275,7 +3286,7 @@ mod tests {
         to_dump.tables.push(part);
         to_dump.tables.push(orders);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3336,7 +3347,7 @@ mod tests {
         from_dump.tables.push(from_table);
         to_dump.tables.push(to_table);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare_tables().await.unwrap();
         let script = comparer.get_script();
 
@@ -3369,7 +3380,7 @@ mod tests {
         from_dump.views.push(from_view);
         to_dump.views.push(to_view);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.create_views().await.unwrap();
         let script = comparer.get_script();
 
@@ -3446,7 +3457,7 @@ mod tests {
         to_dump.routines.push(get_user_count);
         to_dump.views.push(v_user_stats);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3508,7 +3519,7 @@ mod tests {
         to_dump.routines.push(helper_fn);
         to_dump.views.push(mat_view);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3561,7 +3572,7 @@ mod tests {
         from_dump.routines.push(routine_b);
         from_dump.routines.push(routine_a);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3637,7 +3648,7 @@ mod tests {
         to_dump.tables.push(grandparent);
         to_dump.tables.push(sub_parent);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3715,7 +3726,7 @@ mod tests {
         from_dump.tables.push(sub_parent);
         from_dump.tables.push(leaf);
 
-        let mut comparer = Comparer::new(from_dump, to_dump, true);
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3915,7 +3926,7 @@ mod tests {
             None,
         ));
 
-        let mut comparer = Comparer::new(from_dump, to_dump, false);
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false);
         comparer.compare().await.unwrap();
         let script = comparer.get_script();
 
@@ -3956,5 +3967,45 @@ mod tests {
             !script.contains("nextval('test_schema.test_bigserial_id_seq'"),
             "bigserial column should not have explicit nextval default"
         );
+    }
+
+    #[tokio::test]
+    async fn use_single_transaction_should_add_begin_commit() {
+        let from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut new_table = Table::new(
+            "public".to_string(),
+            "my-table".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![int_column("public", "\"my-table\"", "id", 1)],
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
+
+        new_table.hash();
+
+        to_dump.tables.push(new_table);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, false, true);
+
+        comparer.compare().await.unwrap();
+
+        let script = comparer.get_script();
+
+        const SCRIPT_BODY_START_PATTERN: &str = "*/\n\n";
+
+        let script_body_start_index = script
+            .find(SCRIPT_BODY_START_PATTERN)
+            .map(|index| index + SCRIPT_BODY_START_PATTERN.len())
+            .expect("Script header was not found");
+
+        let script_body = &script[script_body_start_index..];
+
+        assert!(script_body.starts_with("begin;\n\n"));
+        assert!(script_body.ends_with("\ncommit;"));
     }
 }

--- a/app/src/config/core.rs
+++ b/app/src/config/core.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub output: String,
     // Whether to use DROP statements in the output
     pub use_drop: bool,
+    // True - if explicit begin...commit statement has to be added into resulting diff file; False - otherwise
+    pub use_single_transaction: bool,
 }
 
 impl Config {
@@ -48,6 +50,7 @@ impl Config {
         let mut to_dump = "dump.to".to_string();
         let mut output = "data.out".to_string();
         let mut use_drop = false;
+        let mut use_single_transaction = false;
 
         for line in &config_data {
             if line.trim().is_empty() || line.starts_with('#') {
@@ -78,6 +81,7 @@ impl Config {
                 && parts[0].trim() != "TO_DUMP"
                 && parts[0].trim() != "OUTPUT"
                 && parts[0].trim() != "USE_DROP"
+                && parts[0].trim() != "USE_SINGLE_TRANSACTION"
             {
                 panic!("Unknown configuration key: {}", parts[0]);
             }
@@ -113,6 +117,9 @@ impl Config {
                 "TO_DUMP" => to_dump = parts[1].trim().to_string(),
                 "OUTPUT" => output = parts[1].trim().to_string(),
                 "USE_DROP" => use_drop = parts[1].trim().to_uppercase() == "TRUE",
+                "USE_SINGLE_TRANSACTION" => {
+                    use_single_transaction = parts[1].trim().to_uppercase() == "TRUE"
+                }
                 _ => {}
             }
         }
@@ -141,6 +148,7 @@ impl Config {
             to,
             output,
             use_drop,
+            use_single_transaction,
         }
     }
 }
@@ -178,6 +186,7 @@ mod tests {
             TO_DUMP=to.dump
             OUTPUT=result.out
             USE_DROP=true
+            USE_SINGLE_TRANSACTION=true
         "#;
         let file = write_temp_config(config_content, "test_valid_config_parsing.cfg");
         let config = Config::new(file.clone());
@@ -193,6 +202,7 @@ mod tests {
         assert_eq!(config.to.file, "to.dump");
         assert_eq!(config.output, "result.out");
         assert!(config.use_drop);
+        assert!(config.use_single_transaction);
         let _ = std::fs::remove_file(file);
     }
 
@@ -244,6 +254,7 @@ mod tests {
             OUTPUT=result.out
             # Comment about USE_DROP
             USE_DROP=true
+            USE_SINGLE_TRANSACTION=true
         "#;
         let file = write_temp_config(
             config_content,
@@ -253,6 +264,7 @@ mod tests {
         assert_eq!(config.from.host, "localhost");
         assert_eq!(config.to.host, "remotehost");
         assert!(config.use_drop);
+        assert!(config.use_single_transaction);
         let _ = std::fs::remove_file(file);
     }
 
@@ -265,6 +277,7 @@ mod tests {
         assert_eq!(config.to.file, "dump.to");
         assert_eq!(config.output, "data.out");
         assert!(!config.use_drop);
+        assert!(!config.use_single_transaction);
         let _ = std::fs::remove_file(file);
     }
 
@@ -326,6 +339,57 @@ mod tests {
         let file = write_temp_config(config_content, "test_use_drop_case_insensitive.cfg");
         let config = Config::new(file.clone());
         assert!(config.use_drop);
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_use_single_transaction_true_value() {
+        let config_content = r#"
+            USE_SINGLE_TRANSACTION=true
+        "#;
+
+        let file = write_temp_config(config_content, "test_use_single_transaction_true_value.cfg");
+
+        let config = Config::new(file.clone());
+
+        assert!(config.use_single_transaction);
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_use_single_transaction_false_value() {
+        let config_content = r#"
+            USE_SINGLE_TRANSACTION=false
+        "#;
+
+        let file = write_temp_config(
+            config_content,
+            "test_use_single_transaction_false_value.cfg",
+        );
+
+        let config = Config::new(file.clone());
+
+        assert!(!config.use_single_transaction);
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_use_single_transaction_case_insensitive() {
+        let config_content = r#"
+            USE_SINGLE_TRANSACTION=TRUE
+        "#;
+
+        let file = write_temp_config(
+            config_content,
+            "test_use_single_transaction_case_insensitive.cfg",
+        );
+
+        let config = Config::new(file.clone());
+
+        assert!(config.use_single_transaction);
+
         let _ = std::fs::remove_file(file);
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -72,6 +72,10 @@ struct Args {
     /// Use DROP statements in the output
     #[arg(long, default_value = "false")]
     use_drop: bool,
+
+    /// True - if explicit begin...commit statement has to be added into resulting diff file; False - otherwise
+    #[arg(long, default_value = "false")]
+    use_single_transaction: bool,
 }
 
 // Main entry point for the program.
@@ -110,6 +114,7 @@ pub async fn main() -> Result<(), Error> {
                     args.to.unwrap(),
                     args.output.unwrap(),
                     args.use_drop,
+                    args.use_single_transaction,
                 )
                 .await;
             }
@@ -142,7 +147,6 @@ async fn run_by_config(config: String) -> Result<(), Error> {
         let from_file = cfg.from.file.clone();
         let to_file = cfg.to.file.clone();
         let output_file = cfg.output.clone();
-        let use_drop = cfg.use_drop;
 
         let result = create_dump(DumpConfig {
             host: cfg.from.host,
@@ -175,7 +179,16 @@ async fn run_by_config(config: String) -> Result<(), Error> {
             return Err(e);
         }
         println!("Dumps created successfully. Now comparing...");
-        let compare_result = compare_dumps(from_file, to_file, output_file, use_drop).await;
+
+        let compare_result = compare_dumps(
+            from_file,
+            to_file,
+            output_file,
+            cfg.use_drop,
+            cfg.use_single_transaction,
+        )
+        .await;
+
         if let Err(e) = compare_result {
             eprintln!("Error comparing dumps: {e}");
             return Err(e);
@@ -206,6 +219,7 @@ async fn compare_dumps(
     to: String,
     output: String,
     use_drop: bool,
+    use_single_transaction: bool,
 ) -> Result<(), Error> {
     println!("Reading dumps...");
     let from = Dump::read_from_file(&from).await?;
@@ -213,7 +227,7 @@ async fn compare_dumps(
     println!("--> Dump from:\n{}\n", from.get_info());
     println!("--> Dump to:\n{}\n", to.get_info());
     println!("Comparing dumps...");
-    let mut comparer = Comparer::new(from, to, use_drop);
+    let mut comparer = Comparer::new(from, to, use_drop, use_single_transaction);
     comparer.compare().await?;
     comparer.save_script(&output).await?;
     println!("Dump compared successfully. Result script: {output}");


### PR DESCRIPTION
Addresses p.1 from #99 

`begin; ... commit;` - is an additional safe net if user forgot to add `--single-transaction` flag while executing diff file via `psql`