### PR TITLE
Fix split_arguments to handle single-quoted strings and UTF-8

### DIFF
--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -459,71 +459,41 @@ impl Routine {
         let mut depth: i32 = 0;
         let mut in_quote = false;
         let mut current = String::new();
+        let mut iter = s.chars().peekable();
 
-        let chars: Vec<(usize, char)> = s.char_indices().collect();
-        let len = chars.len();
-        let mut i = 0;
-
-        while i < len {
-            let (_byte_i, ch) = chars[i];
-
+        while let Some(ch) = iter.next() {
             if in_quote {
                 // Inside a single-quoted string literal.
                 // Two consecutive single quotes represent an escaped quote ('').
                 if ch == '\'' {
-                    if i + 1 < len && chars[i + 1].1 == '\'' {
+                    if iter.peek() == Some(&'\'') {
                         // Escaped quote: consume both characters and stay in-quote.
                         current.push('\'');
-                        current.push('\'');
-                        i += 2;
-                        continue;
+                        current.push(iter.next().unwrap());
                     } else {
                         // Closing quote.
                         in_quote = false;
                         current.push(ch);
-                        i += 1;
-                        continue;
                     }
                 } else {
                     current.push(ch);
-                    i += 1;
-                    continue;
                 }
+                continue;
             }
 
             // Outside any string literal.
             match ch {
-                '\'' => {
-                    in_quote = true;
-                    current.push(ch);
-                    i += 1;
-                }
-                '(' => {
-                    depth += 1;
-                    current.push(ch);
-                    i += 1;
-                }
-                ')' => {
-                    depth -= 1;
-                    current.push(ch);
-                    i += 1;
-                }
+                '\'' => { in_quote = true; current.push(ch); }
+                '(' => { depth += 1; current.push(ch); }
+                ')' => { depth -= 1; current.push(ch); }
                 ',' if depth == 0 => {
-                    parts.push(current.clone());
-                    current.clear();
-                    i += 1;
+                    parts.push(std::mem::take(&mut current));
                 }
-                _ => {
-                    current.push(ch);
-                    i += 1;
-                }
+                _ => { current.push(ch); }
             }
         }
 
-        if !current.is_empty() {
-            parts.push(current);
-        }
-
+        parts.push(current);
         parts
     }
 

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -458,7 +458,6 @@ impl Routine {
         let mut parts = Vec::new();
         let mut depth: i32 = 0;
         let mut in_quote = false;
-        let mut in_dollar_quote: Option<String> = None;
         let mut current = String::new();
 
         let chars: Vec<(usize, char)> = s.char_indices().collect();
@@ -466,7 +465,7 @@ impl Routine {
         let mut i = 0;
 
         while i < len {
-            let (byte_i, ch) = chars[i];
+            let (_byte_i, ch) = chars[i];
 
             if in_quote {
                 // Inside a single-quoted string literal.
@@ -492,43 +491,12 @@ impl Routine {
                 }
             }
 
-            if let Some(ref tag) = in_dollar_quote {
-                // Inside a dollar-quoted string: scan for the closing tag.
-                if ch == '$' && s[byte_i..].starts_with(tag.as_str()) {
-                    // Closing dollar tag found.
-                    current.push_str(tag);
-                    i += tag.chars().count();
-                    in_dollar_quote = None;
-                    continue;
-                } else {
-                    current.push(ch);
-                    i += 1;
-                    continue;
-                }
-            }
-
             // Outside any string literal.
             match ch {
                 '\'' => {
                     in_quote = true;
                     current.push(ch);
                     i += 1;
-                }
-                '$' => {
-                    // Detect dollar-quote opening tag: $tag$ or $$.
-                    // Scan ahead for the next '$'.
-                    let rest = &s[byte_i..];
-                    if let Some(end_offset) = rest[1..].find('$') {
-                        // end_offset is relative to rest[1..], so the closing '$' is at
-                        // position byte_i + 1 + end_offset in the original string.
-                        let tag = &rest[..end_offset + 2]; // includes both '$' delimiters
-                        in_dollar_quote = Some(tag.to_string());
-                        current.push_str(tag);
-                        i += tag.chars().count();
-                    } else {
-                        current.push(ch);
-                        i += 1;
-                    }
                 }
                 '(' => {
                     depth += 1;
@@ -1208,7 +1176,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // split_arguments: single-quote and dollar-quote handling (Issue #154)
+    // split_arguments: single-quote handling (Issue #154)
     // -----------------------------------------------------------------
 
     #[test]
@@ -1241,14 +1209,6 @@ mod tests {
         let input = "a numeric(10,2), b text";
         let result = Routine::split_arguments(input);
         assert_eq!(result, vec!["a numeric(10,2)", " b text"]);
-    }
-
-    #[test]
-    fn split_arguments_dollar_quoted_string() {
-        assert_eq!(
-            Routine::split_arguments("$$hello, world$$, 42"),
-            vec!["$$hello, world$$", " 42"]
-        );
     }
 
     #[test]

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -454,6 +454,11 @@ impl Routine {
     /// single-quoted string literals.
     /// E.g. "a numeric(10,2), b text"    → ["a numeric(10,2)", " b text"]
     /// E.g. "','::character varying, 0"  → ["','::character varying", " 0"]
+    ///
+    /// Dollar-quoted strings (`$$...$$`) are intentionally not handled: both
+    /// call sites receive output from `pg_get_function_identity_arguments` or
+    /// `pg_get_expr(proargdefaults, 0)`, which always produce single-quoted
+    /// expressions and never emit dollar-quotes.
     fn split_arguments(s: &str) -> Vec<String> {
         let mut parts = Vec::new();
         let mut depth = 0;
@@ -469,7 +474,7 @@ impl Routine {
                     if iter.peek() == Some(&'\'') {
                         // Escaped quote: consume both characters and stay in-quote.
                         current.push('\'');
-                        current.push(iter.next().unwrap());
+                        current.push(iter.next().unwrap()); // safe: peek() confirmed Some above
                     } else {
                         // Closing quote.
                         in_quote = false;
@@ -507,6 +512,7 @@ impl Routine {
         if !current.is_empty() {
             parts.push(current);
         }
+        debug_assert!(!in_quote, "split_arguments: unclosed single-quote in input: {s:?}");
         parts
     }
 

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -1194,6 +1194,62 @@ mod tests {
         assert_eq!(result, vec!["a numeric(10,2)", " b text"]);
     }
 
+    // -----------------------------------------------------------------
+    // split_arguments: JSONB default with commas (Issue #155)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn split_arguments_jsonb_default_with_commas() {
+        // A JSONB literal default containing multiple comma-separated key-value
+        // pairs must not be split into multiple arguments.
+        let input = r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#;
+        let result = Routine::split_arguments(input);
+        assert_eq!(
+            result,
+            vec![r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#]
+        );
+    }
+
+    #[test]
+    fn split_arguments_jsonb_default_multiple_args() {
+        // JSONB default alongside other arguments: only the top-level comma
+        // (outside the single-quoted literal) must be treated as a delimiter.
+        let input = r#"id integer, opts jsonb DEFAULT '{"a": 1, "b": 2}'::jsonb"#;
+        let result = Routine::split_arguments(input);
+        assert_eq!(
+            result,
+            vec![
+                "id integer",
+                r#" opts jsonb DEFAULT '{"a": 1, "b": 2}'::jsonb"#
+            ]
+        );
+    }
+
+    #[test]
+    fn arguments_with_defaults_jsonb_default() {
+        // Full round-trip for Issue #155: a function with a multi-key JSONB
+        // default must reconstruct the full default without splitting on the
+        // commas inside the quoted literal.
+        let routine = Routine::new(
+            "test_schema".to_string(),
+            Oid(400),
+            "foo".to_string(),
+            "plpgsql".to_string(),
+            "FUNCTION".to_string(),
+            "void".to_string(),
+            "p jsonb".to_string(),
+            Some(r#"'{"key1": "value1", "key2": "value2"}'::jsonb"#.to_string()),
+            None,
+            "BEGIN END".to_string(),
+        );
+
+        let result = routine.arguments_with_defaults();
+        assert_eq!(
+            result,
+            r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#
+        );
+    }
+
     #[test]
     fn arguments_with_defaults_comma_default() {
         // Full round-trip: a procedure with two varchar params where only the

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -461,18 +461,18 @@ impl Routine {
         let mut in_dollar_quote: Option<String> = None;
         let mut current = String::new();
 
-        let chars: Vec<char> = s.chars().collect();
+        let chars: Vec<(usize, char)> = s.char_indices().collect();
         let len = chars.len();
         let mut i = 0;
 
         while i < len {
-            let ch = chars[i];
+            let (byte_i, ch) = chars[i];
 
             if in_quote {
                 // Inside a single-quoted string literal.
                 // Two consecutive single quotes represent an escaped quote ('').
                 if ch == '\'' {
-                    if i + 1 < len && chars[i + 1] == '\'' {
+                    if i + 1 < len && chars[i + 1].1 == '\'' {
                         // Escaped quote: consume both characters and stay in-quote.
                         current.push('\'');
                         current.push('\'');
@@ -492,12 +492,12 @@ impl Routine {
                 }
             }
 
-            if let Some(ref tag) = in_dollar_quote.clone() {
+            if let Some(ref tag) = in_dollar_quote {
                 // Inside a dollar-quoted string: scan for the closing tag.
-                if ch == '$' && s[i..].starts_with(tag.as_str()) {
+                if ch == '$' && s[byte_i..].starts_with(tag.as_str()) {
                     // Closing dollar tag found.
                     current.push_str(tag);
-                    i += tag.len();
+                    i += tag.chars().count();
                     in_dollar_quote = None;
                     continue;
                 } else {
@@ -517,14 +517,14 @@ impl Routine {
                 '$' => {
                     // Detect dollar-quote opening tag: $tag$ or $$.
                     // Scan ahead for the next '$'.
-                    let rest = &s[i..];
+                    let rest = &s[byte_i..];
                     if let Some(end_offset) = rest[1..].find('$') {
                         // end_offset is relative to rest[1..], so the closing '$' is at
-                        // position i + 1 + end_offset in the original string.
+                        // position byte_i + 1 + end_offset in the original string.
                         let tag = &rest[..end_offset + 2]; // includes both '$' delimiters
                         in_dollar_quote = Some(tag.to_string());
                         current.push_str(tag);
-                        i += tag.len();
+                        i += tag.chars().count();
                     } else {
                         current.push(ch);
                         i += 1;
@@ -1241,6 +1241,14 @@ mod tests {
         let input = "a numeric(10,2), b text";
         let result = Routine::split_arguments(input);
         assert_eq!(result, vec!["a numeric(10,2)", " b text"]);
+    }
+
+    #[test]
+    fn split_arguments_dollar_quoted_string() {
+        assert_eq!(
+            Routine::split_arguments("$$hello, world$$, 42"),
+            vec!["$$hello, world$$", " 42"]
+        );
     }
 
     #[test]

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -1226,6 +1226,16 @@ mod tests {
     }
 
     #[test]
+    fn split_arguments_jsonb_default_multiline() {
+        // A multiline JSONB literal (containing newlines inside the quoted string)
+        // must be treated as a single argument — newlines and commas inside the
+        // single-quoted literal must not trigger a split.
+        let input = "p jsonb DEFAULT '{\n    \"key1\": \"value1\",\n    \"key2\": \"value2\"\n}'::jsonb";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec![input]);
+    }
+
+    #[test]
     fn arguments_with_defaults_jsonb_default() {
         // Full round-trip for Issue #155: a function with a multi-key JSONB
         // default must reconstruct the full default without splitting on the

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn arguments_with_defaults_jsonb_default() {
-        // Full round-trip for Issue #155: a function with a multi-key JSONB
+        // Full round-trip for Issue #154: a function with a multi-key JSONB
         // default must reconstruct the full default without splitting on the
         // commas inside the quoted literal.
         let routine = Routine::new(

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -456,7 +456,7 @@ impl Routine {
     /// E.g. "','::character varying, 0"  → ["','::character varying", " 0"]
     fn split_arguments(s: &str) -> Vec<String> {
         let mut parts = Vec::new();
-        let mut depth: i32 = 0;
+        let mut depth = 0;
         let mut in_quote = false;
         let mut current = String::new();
         let mut iter = s.chars().peekable();
@@ -483,13 +483,24 @@ impl Routine {
 
             // Outside any string literal.
             match ch {
-                '\'' => { in_quote = true; current.push(ch); }
-                '(' => { depth += 1; current.push(ch); }
-                ')' => { depth -= 1; current.push(ch); }
+                '\'' => {
+                    in_quote = true;
+                    current.push(ch);
+                }
+                '(' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' => {
+                    depth -= 1;
+                    current.push(ch);
+                }
                 ',' if depth == 0 => {
                     parts.push(std::mem::take(&mut current));
                 }
-                _ => { current.push(ch); }
+                _ => {
+                    current.push(ch);
+                }
             }
         }
 

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -450,29 +450,104 @@ impl Routine {
         result_parts.join(", ")
     }
 
-    /// Splits a comma-separated string respecting parenthesized groups.
-    /// E.g. "a numeric(10,2), b text" → ["a numeric(10,2)", " b text"]
+    /// Splits a comma-separated string respecting parenthesized groups and
+    /// single-quoted string literals.
+    /// E.g. "a numeric(10,2), b text"    → ["a numeric(10,2)", " b text"]
+    /// E.g. "','::character varying, 0"  → ["','::character varying", " 0"]
     fn split_arguments(s: &str) -> Vec<String> {
         let mut parts = Vec::new();
-        let mut depth = 0;
+        let mut depth: i32 = 0;
+        let mut in_quote = false;
+        let mut in_dollar_quote: Option<String> = None;
         let mut current = String::new();
 
-        for ch in s.chars() {
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
+        let mut i = 0;
+
+        while i < len {
+            let ch = chars[i];
+
+            if in_quote {
+                // Inside a single-quoted string literal.
+                // Two consecutive single quotes represent an escaped quote ('').
+                if ch == '\'' {
+                    if i + 1 < len && chars[i + 1] == '\'' {
+                        // Escaped quote: consume both characters and stay in-quote.
+                        current.push('\'');
+                        current.push('\'');
+                        i += 2;
+                        continue;
+                    } else {
+                        // Closing quote.
+                        in_quote = false;
+                        current.push(ch);
+                        i += 1;
+                        continue;
+                    }
+                } else {
+                    current.push(ch);
+                    i += 1;
+                    continue;
+                }
+            }
+
+            if let Some(ref tag) = in_dollar_quote.clone() {
+                // Inside a dollar-quoted string: scan for the closing tag.
+                if ch == '$' && s[i..].starts_with(tag.as_str()) {
+                    // Closing dollar tag found.
+                    current.push_str(tag);
+                    i += tag.len();
+                    in_dollar_quote = None;
+                    continue;
+                } else {
+                    current.push(ch);
+                    i += 1;
+                    continue;
+                }
+            }
+
+            // Outside any string literal.
             match ch {
+                '\'' => {
+                    in_quote = true;
+                    current.push(ch);
+                    i += 1;
+                }
+                '$' => {
+                    // Detect dollar-quote opening tag: $tag$ or $$.
+                    // Scan ahead for the next '$'.
+                    let rest = &s[i..];
+                    if let Some(end_offset) = rest[1..].find('$') {
+                        // end_offset is relative to rest[1..], so the closing '$' is at
+                        // position i + 1 + end_offset in the original string.
+                        let tag = &rest[..end_offset + 2]; // includes both '$' delimiters
+                        in_dollar_quote = Some(tag.to_string());
+                        current.push_str(tag);
+                        i += tag.len();
+                    } else {
+                        current.push(ch);
+                        i += 1;
+                    }
+                }
                 '(' => {
                     depth += 1;
                     current.push(ch);
+                    i += 1;
                 }
                 ')' => {
                     depth -= 1;
                     current.push(ch);
+                    i += 1;
                 }
                 ',' if depth == 0 => {
                     parts.push(current.clone());
                     current.clear();
+                    i += 1;
                 }
                 _ => {
                     current.push(ch);
+                    i += 1;
                 }
             }
         }
@@ -1129,6 +1204,66 @@ mod tests {
             script.contains("create aggregate public.my_mode(ORDER BY anyelement)"),
             "Expected ordered-set syntax with no direct args, got: {}",
             script
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // split_arguments: single-quote and dollar-quote handling (Issue #154)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn split_arguments_respects_single_quoted_comma() {
+        // A single default value whose expression contains a comma inside quotes.
+        let input = "','::character varying";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["','::character varying"]);
+    }
+
+    #[test]
+    fn split_arguments_multiple_defaults_with_quoted_comma() {
+        // Two defaults: the first contains a quoted comma, the second is a plain number.
+        let input = "','::character varying, 0";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["','::character varying", " 0"]);
+    }
+
+    #[test]
+    fn split_arguments_escaped_quotes() {
+        // Two defaults: the first uses escaped single-quotes ('' inside a string).
+        let input = "'''hello'''::text, 42";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["'''hello'''::text", " 42"]);
+    }
+
+    #[test]
+    fn split_arguments_parenthesized_still_works() {
+        // Existing behaviour: parenthesised type expressions must not be split.
+        let input = "a numeric(10,2), b text";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["a numeric(10,2)", " b text"]);
+    }
+
+    #[test]
+    fn arguments_with_defaults_comma_default() {
+        // Full round-trip: a procedure with two varchar params where only the
+        // second has a default of ','::character varying.
+        let routine = Routine::new(
+            "test_schema".to_string(),
+            Oid(300),
+            "format_csv_line".to_string(),
+            "plpgsql".to_string(),
+            "PROCEDURE".to_string(),
+            "void".to_string(),
+            "p_value character varying, p_delimiter character varying".to_string(),
+            Some("','::character varying".to_string()),
+            None,
+            "BEGIN RAISE NOTICE '%', p_value || p_delimiter; END".to_string(),
+        );
+
+        let result = routine.arguments_with_defaults();
+        assert_eq!(
+            result,
+            "p_value character varying, p_delimiter character varying DEFAULT ','::character varying"
         );
     }
 }

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // split_arguments: JSONB default with commas (Issue #155)
+    // split_arguments: JSONB default with commas (Issue #154)
     // -----------------------------------------------------------------
 
     #[test]

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -504,7 +504,9 @@ impl Routine {
             }
         }
 
-        parts.push(current);
+        if !current.is_empty() {
+            parts.push(current);
+        }
         parts
     }
 

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -162,6 +162,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 #### Unchanged Procedures
 - **notify_event(uuid, varchar, jsonb)**: 3-param overload, identical in both schemas
 - **notify_event(uuid, varchar, varchar, jsonb, jsonb)**: 5-param overload, identical in both schemas (tests overloaded routine matching by argument signature)
+- **format_csv_line(varchar, varchar)**: procedure with a comma-in-string default (`DEFAULT ','`) - identical in both schemas; no diff should be emitted (Issue #154 regression test)
 
 ### 12. Triggers
 - **Added**: `trigger_reviews_update_timestamp`, `trigger_reviews_audit` on `reviews` table
@@ -263,6 +264,12 @@ Grant comparison test using roles `pgc_grant_reader` and `pgc_grant_writer`.
 #### Routine Dependency Ordering
 - View ↔ routine cross-dependencies: `get_user_count()` → `v_user_stats` → `report_user_stats()` / `print_user_stats()`
 - Routine chain: `r_base_value()` → `x_step_one()` → `a_middle_layer()` → `z_final_report()`
+
+#### Comma-in-String Default (Issue #154)
+- `test_schema.format_csv_line(p_value varchar, p_delimiter varchar DEFAULT ',')` is present and identical in both schemas
+- PostgreSQL stores the default separately via `pg_get_expr(proargdefaults, 0)`, which returns `','::character varying`
+- The comma inside the quoted string literal must not be treated as a delimiter when splitting the defaults string
+- The comparer must produce no diff for this procedure, confirming the round-trip is correct
 
 ---
 

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -377,8 +377,19 @@ BEGIN
     DELETE FROM test_schema.orders
     WHERE created_at < CURRENT_DATE - INTERVAL '1 day' * days_old
     AND status = 'delivered';
-    
+
     COMMIT;
+END;
+$$;
+
+-- Procedure with comma-in-string default (Issue #154 regression test)
+CREATE OR REPLACE PROCEDURE test_schema.format_csv_line(
+    p_value varchar,
+    p_delimiter varchar DEFAULT ','
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE NOTICE '%', p_value || p_delimiter;
 END;
 $$;
 

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -415,8 +415,19 @@ BEGIN
     DELETE FROM test_schema.reviews
     WHERE created_at < CURRENT_DATE - INTERVAL '1 day' * days_old
     AND helpful_count = 0;
-    
+
     COMMIT;
+END;
+$$;
+
+-- Procedure with comma-in-string default (Issue #154 regression test)
+CREATE OR REPLACE PROCEDURE test_schema.format_csv_line(
+    p_value varchar,
+    p_delimiter varchar DEFAULT ','
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE NOTICE '%', p_value || p_delimiter;
 END;
 $$;
 


### PR DESCRIPTION
This pull request improves the parsing logic for routine argument defaults in order to correctly handle cases where a comma appears inside a single-quoted string, such as in default values like `DEFAULT ','`. It ensures that such commas are not incorrectly treated as argument separators, addressing Issue #154. The change is thoroughly tested and includes regression tests in the codebase and test schemas.

**Parsing improvements:**

* Updated the `split_arguments` function in `routine.rs` to correctly handle single-quoted string literals, including escaped quotes, so that commas inside quoted strings are not treated as delimiters. This prevents incorrect splitting of argument lists when default values contain commas in strings.

**Testing and regression coverage:**

* Added multiple unit tests for `split_arguments` to verify correct handling of single-quoted commas, escaped quotes, and parenthesized expressions, ensuring robust parsing and preventing regressions.
* Added a new test procedure `format_csv_line` with a comma-in-string default value to both test schemas (`schema_a.sql` and `schema_b.sql`) as a regression test for Issue #154. [[1]](diffhunk://#diff-b388b3970fa64108c8e8fe433b69c2ebec77c9ed9d5e704bf5c5d3273b6c7736R385-R395) [[2]](diffhunk://#diff-38b6e1751bd3fbc31ee47c85ca7237ead83a97ac683d776ca37df834acf19272R423-R433)
* Updated test documentation (`README.md`) to describe the new regression test and clarify the expected behavior when comparing schemas with procedures containing comma-in-string defaults. [[1]](diffhunk://#diff-3282211255c32bea0dd70d4d52d72eefa25fe28d89855e5ac32773d8d04409acR165) [[2]](diffhunk://#diff-3282211255c32bea0dd70d4d52d72eefa25fe28d89855e5ac32773d8d04409acR268-R273)