### PR TITLE
Apply v1.0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ database.sql
 docker-compose.override.yml
 .env
 *.dump
+
+.claude/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
                 v1.0.12
                     - Fixed splitting arguments issue.
+                    - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
 
 2026-04-07      v1.0.11
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
                 v1.0.12
                     - Fixed splitting arguments issue.
                     - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
-                    - `coninhcount` i16 -> i32
+                    - `coninhcount` i16 -> i32.
+                    - Fixed altering sequences with values.
 
 2026-04-07      v1.0.11
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-                v1.0.12
+2026-04-08      v1.0.12
+
+                Features:
                     - Fixed splitting arguments issue.
                     - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
                     - `coninhcount` i16 -> i32.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
                 v1.0.12
                     - Fixed splitting arguments issue.
                     - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
+                    - `coninhcount` i16 -> i32
 
 2026-04-07      v1.0.11
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+                v1.0.12
+                    - Fixed splitting arguments issue.
+
 2026-04-07      v1.0.11
 
                 Features:

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ CMD ["pgc", "--help"]
 # Metadata
 LABEL maintainer="nettrash" \
       description="PostgreSQL Database Comparer (PGC) - A tool for comparing PostgreSQL database schemas" \
-      version="1.0.11" \
+      version="1.0.12" \
       org.opencontainers.image.title="pgc" \
       org.opencontainers.image.description="PostgreSQL Database Comparer" \
-      org.opencontainers.image.version="1.0.11" \
+      org.opencontainers.image.version="1.0.12" \
       org.opencontainers.image.source="https://github.com/nettrash/pgc" \
       org.opencontainers.image.licenses="MIT"

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -1146,7 +1146,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgc"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "chrono",
  "clap",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgc"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2024"
 license = "MIT"
 

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -31,7 +31,7 @@ pub struct Comparer {
     type_post_script: String,
     sequence_post_script: String,
     trigger_post_script: String,
-    dropped_views: HashSet<String>,
+    dropped_views: HashMap<String, bool>,
     // Tracks columns that should use serial/bigserial/smallserial type.
     // Key: "schema.table.column", Value: "serial", "bigserial", or "smallserial".
     serial_columns: HashMap<String, String>,
@@ -60,7 +60,7 @@ impl Comparer {
             type_post_script: String::new(),
             sequence_post_script: String::new(),
             trigger_post_script: String::new(),
-            dropped_views: HashSet::new(),
+            dropped_views: HashMap::new(),
             serial_columns: HashMap::new(),
         };
 
@@ -868,7 +868,7 @@ impl Comparer {
                     self.script.push_str(
                         format!("/* Type: {}.{} */\n", to_type.schema, to_type.typname).as_str(),
                     );
-                    let alter_script = from_type.get_alter_script(to_type);
+                    let alter_script = from_type.get_alter_script(to_type, self.use_drop);
                     if alter_script.trim().is_empty() {
                         self.script.push_str(
                             "-- No supported alterations for this type; manual review required.\n",
@@ -981,7 +981,7 @@ impl Comparer {
                     create_alter_section.push_str(
                         format!("/* Enum: {}.{} */\n", to_enum.schema, to_enum.typname).as_str(),
                     );
-                    let alter_script = from_enum.get_alter_script(to_enum);
+                    let alter_script = from_enum.get_alter_script(to_enum, self.use_drop);
                     if alter_script.trim().is_empty() {
                         create_alter_section.push_str(
                             "-- No supported alterations for this enum; manual review required.\n",
@@ -1477,7 +1477,17 @@ impl Comparer {
                                 constraint.schema, constraint.table_name, constraint.name
                             );
                             if dropped_fk_keys.insert(key) {
-                                fk_pre_drop.push_str(&constraint.get_drop_script());
+                                let drop_cmd = constraint.get_drop_script();
+                                if self.use_drop {
+                                    fk_pre_drop.push_str(&drop_cmd);
+                                } else {
+                                    fk_pre_drop.push_str(
+                                        &drop_cmd
+                                            .lines()
+                                            .map(|l| format!("-- {}\n", l))
+                                            .collect::<String>(),
+                                    );
+                                }
                             }
                         }
                     }
@@ -1504,10 +1514,15 @@ impl Comparer {
 
             // Drop triggers on the table
             for trigger in &table.triggers {
-                pre_drop.append_block(&format!(
+                let drop_cmd = format!(
                     "drop trigger if exists {} on {}.{};",
                     trigger.name, table.schema, table.name
-                ));
+                );
+                if self.use_drop {
+                    pre_drop.append_block(&drop_cmd);
+                } else {
+                    pre_drop.append_block(&format!("-- {}", drop_cmd));
+                }
             }
 
             self.script
@@ -1771,12 +1786,24 @@ impl Comparer {
                     .map(|tv| Self::hashes_differ(&from_view.hash, &tv.hash))
                     .unwrap_or(false);
 
-            let should_drop =
-                is_dependent || (self.use_drop && is_from_only) || is_changed_mat_view;
+            // Kind transition (regular <-> materialized) requires drop+recreate
+            // because neither supports an in-place ALTER to the other kind.
+            let is_kind_transition = to_view
+                .map(|tv| from_view.is_materialized != tv.is_materialized)
+                .unwrap_or(false);
+
+            let should_drop = is_dependent
+                || (self.use_drop && is_from_only)
+                || is_changed_mat_view
+                || is_kind_transition;
 
             if should_drop {
-                let force_drop = self.use_drop || is_changed_mat_view;
-                candidates.push((idx, normalized_view, force_drop));
+                // The drop is emitted as active SQL only when use_drop is true.
+                // Changed materialized views still *need* a drop+recreate, but when
+                // use_drop is false the DROP (and its dependent CREATE) are commented
+                // out so the user can review them manually.
+                let drop_is_active = self.use_drop;
+                candidates.push((idx, normalized_view, drop_is_active));
             }
         }
 
@@ -1847,7 +1874,8 @@ impl Comparer {
                         .as_str(),
                 );
             }
-            self.dropped_views.insert(normalized_view.clone());
+            self.dropped_views
+                .insert(normalized_view.clone(), force_drop);
         }
 
         self.script
@@ -1871,7 +1899,12 @@ impl Comparer {
                 .find(|view| view.schema == to_view.schema && view.name == to_view.name);
 
             let existed_in_from = from_view.is_some();
-            let was_dropped = self.dropped_views.contains(&normalized_view);
+            let was_dropped = self.dropped_views.contains_key(&normalized_view);
+            let drop_was_active = self
+                .dropped_views
+                .get(&normalized_view)
+                .copied()
+                .unwrap_or(false);
             let definition_changed = from_view
                 .map(|fv| Self::hashes_differ(&fv.hash, &to_view.hash))
                 .unwrap_or(false);
@@ -1895,7 +1928,22 @@ impl Comparer {
             if to_view.is_materialized {
                 // Materialized views do not support CREATE OR REPLACE — get_script()
                 // already emits the correct CREATE MATERIALIZED VIEW syntax.
-                self.script.push_str(&to_view.get_script());
+                if was_dropped && !drop_was_active {
+                    // DROP was commented out, so CREATE would fail; comment it out too.
+                    let create_script = to_view.get_script();
+                    self.script.push_str(&format!(
+                        "-- use_drop=false: materialized view {}.{} requires drop+recreate; create commented out (manual intervention needed)\n",
+                        to_view.schema, to_view.name
+                    ));
+                    self.script.push_str(
+                        &create_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                    );
+                } else {
+                    self.script.push_str(&to_view.get_script());
+                }
             } else {
                 let mut view_script = to_view.get_script();
                 if !view_script
@@ -1909,7 +1957,22 @@ impl Comparer {
                         view_script.replace_range(pos..pos + TARGET.len(), REPLACEMENT);
                     }
                 }
-                self.script.push_str(&view_script);
+                if was_dropped && !drop_was_active {
+                    // Kind transition (mat→regular): DROP was commented, so
+                    // CREATE OR REPLACE VIEW would fail; comment it out too.
+                    self.script.push_str(&format!(
+                        "-- use_drop=false: view {}.{} requires drop+recreate (kind transition); create commented out (manual intervention needed)\n",
+                        to_view.schema, to_view.name
+                    ));
+                    self.script.push_str(
+                        &view_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                    );
+                } else {
+                    self.script.push_str(&view_script);
+                }
             }
         }
 
@@ -1924,7 +1987,28 @@ impl Comparer {
             .push_str(format!("/* View: {}.{}*/\n", to_view.schema, to_view.name).as_str());
 
         if to_view.is_materialized {
-            self.script.push_str(&to_view.get_script());
+            let normalized_view = Self::normalized_view_key(&to_view.schema, &to_view.name);
+            let drop_was_active = self
+                .dropped_views
+                .get(&normalized_view)
+                .copied()
+                .unwrap_or(true);
+            if !drop_was_active {
+                // DROP was commented out, so CREATE would fail; comment it out too.
+                let create_script = to_view.get_script();
+                self.script.push_str(&format!(
+                    "-- use_drop=false: materialized view {}.{} requires drop+recreate; create commented out (manual intervention needed)\n",
+                    to_view.schema, to_view.name
+                ));
+                self.script.push_str(
+                    &create_script
+                        .lines()
+                        .map(|l| format!("-- {}\n", l))
+                        .collect::<String>(),
+                );
+            } else {
+                self.script.push_str(&to_view.get_script());
+            }
         } else {
             let mut view_script = to_view.get_script();
             if !view_script
@@ -1937,7 +2021,29 @@ impl Comparer {
                     view_script.replace_range(pos..pos + TARGET.len(), REPLACEMENT);
                 }
             }
-            self.script.push_str(&view_script);
+            let normalized_view = Self::normalized_view_key(&to_view.schema, &to_view.name);
+            let drop_was_active = self
+                .dropped_views
+                .get(&normalized_view)
+                .copied()
+                .unwrap_or(true);
+            let was_dropped = self.dropped_views.contains_key(&normalized_view);
+            if was_dropped && !drop_was_active {
+                // Kind transition (mat→regular): DROP was commented, so
+                // CREATE OR REPLACE VIEW would fail; comment it out too.
+                self.script.push_str(&format!(
+                    "-- use_drop=false: view {}.{} requires drop+recreate (kind transition); create commented out (manual intervention needed)\n",
+                    to_view.schema, to_view.name
+                ));
+                self.script.push_str(
+                    &view_script
+                        .lines()
+                        .map(|l| format!("-- {}\n", l))
+                        .collect::<String>(),
+                );
+            } else {
+                self.script.push_str(&view_script);
+            }
         }
     }
 
@@ -2062,7 +2168,7 @@ impl Comparer {
                 .views
                 .iter()
                 .find(|v| v.schema == view.schema && v.name == view.name);
-            let was_dropped = self.dropped_views.contains(&normalized_view);
+            let was_dropped = self.dropped_views.contains_key(&normalized_view);
             let definition_changed = from_view
                 .map(|fv| Self::hashes_differ(&fv.hash, &view.hash))
                 .unwrap_or(false);
@@ -2392,7 +2498,7 @@ impl Comparer {
             // dependency of an altered table), its ACL will be lost after
             // the DROP.  Treat from_acl as empty so that all required
             // grants are emitted in the migration script.
-            let (from_acl, from_owner) = if self.dropped_views.contains(&normalized_key) {
+            let (from_acl, from_owner) = if self.dropped_views.contains_key(&normalized_key) {
                 (&[] as &[String], "")
             } else {
                 from_view_map
@@ -3189,6 +3295,7 @@ mod tests {
     use crate::dump::table::Table;
     use crate::dump::table_column::TableColumn;
     use crate::dump::table_constraint::TableConstraint;
+    use crate::dump::table_trigger::TableTrigger;
     use crate::dump::view::View;
 
     fn int_column(schema: &str, table: &str, name: &str, ordinal: i32) -> TableColumn {
@@ -5569,7 +5676,7 @@ mod tests {
         // (e.g. as a dependency of an altered table).
         comparer
             .dropped_views
-            .insert(Comparer::normalized_view_key("public", "my_view"));
+            .insert(Comparer::normalized_view_key("public", "my_view"), true);
         comparer.compare_grants().await.unwrap();
         let script = comparer.get_script();
 
@@ -6751,6 +6858,460 @@ mod tests {
         assert!(
             pos_drop < pos_us,
             "events_2023 must be dropped before events_2023_us is created"
+        );
+    }
+
+    #[tokio::test]
+    async fn fk_pre_drop_commented_when_use_drop_false() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        // "from" has a table referenced by FK
+        let mut referenced = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![int_column("public", "users", "id", 1)],
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
+        referenced.hash();
+
+        // "from" has a table with FK referencing "users"
+        let mut referencing = Table::new(
+            "public".to_string(),
+            "orders".to_string(),
+            "public".to_string(),
+            "orders".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                int_column("public", "orders", "id", 1),
+                int_column("public", "orders", "user_id", 2),
+            ],
+            vec![TableConstraint {
+                catalog: "postgres".to_string(),
+                schema: "public".to_string(),
+                name: "orders_user_fk".to_string(),
+                table_name: "orders".to_string(),
+                constraint_type: "FOREIGN KEY".to_string(),
+                is_deferrable: false,
+                initially_deferred: false,
+                definition: Some("FOREIGN KEY (user_id) REFERENCES public.users(id)".to_string()),
+                coninhcount: 0,
+            }],
+            vec![],
+            vec![],
+            None,
+        );
+        referencing.hash();
+
+        from_dump.tables.push(referenced.clone());
+        from_dump.tables.push(referencing.clone());
+
+        // "to" has only "orders" — "users" is being dropped, so its FK must be pre-dropped
+        to_dump.tables.push(referencing);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.compare().await.unwrap();
+        let script = comparer.get_script();
+
+        // FK drop should be commented out because use_drop=false
+        let has_commented_fk_drop = script.lines().any(|l| {
+            l.starts_with("--") && l.contains("drop constraint") && l.contains("orders_user_fk")
+        });
+        assert!(
+            has_commented_fk_drop,
+            "FK pre-drop should be commented out when use_drop=false, script:\n{}",
+            script
+        );
+
+        // Should NOT have an active (uncommented) drop constraint for the FK
+        let has_active_fk_drop = script.lines().any(|l| {
+            !l.starts_with("--") && l.contains("drop constraint") && l.contains("orders_user_fk")
+        });
+        assert!(
+            !has_active_fk_drop,
+            "FK pre-drop should NOT be active when use_drop=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn fk_pre_drop_active_when_use_drop_true() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut referenced = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![int_column("public", "users", "id", 1)],
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
+        referenced.hash();
+
+        let mut referencing = Table::new(
+            "public".to_string(),
+            "orders".to_string(),
+            "public".to_string(),
+            "orders".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                int_column("public", "orders", "id", 1),
+                int_column("public", "orders", "user_id", 2),
+            ],
+            vec![TableConstraint {
+                catalog: "postgres".to_string(),
+                schema: "public".to_string(),
+                name: "orders_user_fk".to_string(),
+                table_name: "orders".to_string(),
+                constraint_type: "FOREIGN KEY".to_string(),
+                is_deferrable: false,
+                initially_deferred: false,
+                definition: Some("FOREIGN KEY (user_id) REFERENCES public.users(id)".to_string()),
+                coninhcount: 0,
+            }],
+            vec![],
+            vec![],
+            None,
+        );
+        referencing.hash();
+
+        from_dump.tables.push(referenced.clone());
+        from_dump.tables.push(referencing.clone());
+        to_dump.tables.push(referencing);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+        comparer.compare().await.unwrap();
+        let script = comparer.get_script();
+
+        let has_active_fk_drop = script.lines().any(|l| {
+            !l.starts_with("--") && l.contains("drop constraint") && l.contains("orders_user_fk")
+        });
+        assert!(
+            has_active_fk_drop,
+            "FK pre-drop should be active when use_drop=true, script:\n{}",
+            script
+        );
+    }
+
+    #[tokio::test]
+    async fn trigger_pre_drop_commented_when_use_drop_false() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let to_dump = Dump::new(DumpConfig::default());
+
+        // "from" has a table with a trigger; table is absent in "to"
+        let mut table_with_trigger = Table::new(
+            "public".to_string(),
+            "events".to_string(),
+            "public".to_string(),
+            "events".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![int_column("public", "events", "id", 1)],
+            vec![],
+            vec![],
+            vec![TableTrigger {
+                oid: Oid(9999),
+                name: "trg_events_audit".to_string(),
+                definition: "before insert on events for each row execute function audit()"
+                    .to_string(),
+            }],
+            None,
+        );
+        table_with_trigger.hash();
+
+        from_dump.tables.push(table_with_trigger);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.compare().await.unwrap();
+        let script = comparer.get_script();
+
+        // Trigger drop should be commented out when use_drop=false
+        let has_commented_trigger_drop = script.lines().any(|l| {
+            l.starts_with("--") && l.contains("drop trigger") && l.contains("trg_events_audit")
+        });
+        assert!(
+            has_commented_trigger_drop,
+            "Trigger pre-drop should be commented when use_drop=false, script:\n{}",
+            script
+        );
+
+        let has_active_trigger_drop = script.lines().any(|l| {
+            !l.starts_with("--") && l.contains("drop trigger") && l.contains("trg_events_audit")
+        });
+        assert!(
+            !has_active_trigger_drop,
+            "Trigger pre-drop should NOT be active when use_drop=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn trigger_pre_drop_active_when_use_drop_true() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let to_dump = Dump::new(DumpConfig::default());
+
+        let mut table_with_trigger = Table::new(
+            "public".to_string(),
+            "events".to_string(),
+            "public".to_string(),
+            "events".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![int_column("public", "events", "id", 1)],
+            vec![],
+            vec![],
+            vec![TableTrigger {
+                oid: Oid(9999),
+                name: "trg_events_audit".to_string(),
+                definition: "before insert on events for each row execute function audit()"
+                    .to_string(),
+            }],
+            None,
+        );
+        table_with_trigger.hash();
+
+        from_dump.tables.push(table_with_trigger);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+        comparer.compare().await.unwrap();
+        let script = comparer.get_script();
+
+        let has_active_trigger_drop = script.lines().any(|l| {
+            !l.starts_with("--") && l.contains("drop trigger") && l.contains("trg_events_audit")
+        });
+        assert!(
+            has_active_trigger_drop,
+            "Trigger pre-drop should be active when use_drop=true, script:\n{}",
+            script
+        );
+    }
+
+    // ------ Kind-transition tests (regular <-> materialized) ------
+
+    #[tokio::test]
+    async fn kind_transition_regular_to_materialized_use_drop_true() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut from_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        from_view.is_materialized = false;
+        from_view.hash();
+        from_dump.views.push(from_view);
+
+        let mut to_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        to_view.is_materialized = true;
+        to_view.hash();
+        to_dump.views.push(to_view);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        comparer.create_views().await.unwrap();
+        let script = comparer.get_script();
+
+        // DROP VIEW (regular) should be active
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop view"));
+        assert!(
+            has_active_drop,
+            "Regular→mat: DROP VIEW should be active when use_drop=true, script:\n{}",
+            script
+        );
+        // CREATE MATERIALIZED VIEW should be active
+        let has_active_create = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("create materialized view"));
+        assert!(
+            has_active_create,
+            "Regular→mat: CREATE MATERIALIZED VIEW should be active when use_drop=true, script:\n{}",
+            script
+        );
+    }
+
+    #[tokio::test]
+    async fn kind_transition_regular_to_materialized_use_drop_false() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut from_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        from_view.is_materialized = false;
+        from_view.hash();
+        from_dump.views.push(from_view);
+
+        let mut to_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        to_view.is_materialized = true;
+        to_view.hash();
+        to_dump.views.push(to_view);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        comparer.create_views().await.unwrap();
+        let script = comparer.get_script();
+
+        // DROP should be commented
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop view"));
+        assert!(
+            !has_active_drop,
+            "Regular→mat: DROP VIEW should be commented when use_drop=false, script:\n{}",
+            script
+        );
+        // CREATE should be commented (manual intervention needed)
+        let has_active_create = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("create materialized view"));
+        assert!(
+            !has_active_create,
+            "Regular→mat: CREATE MATERIALIZED VIEW should be commented when use_drop=false, script:\n{}",
+            script
+        );
+        assert!(
+            script.contains("manual intervention needed"),
+            "Should contain manual intervention warning, script:\n{}",
+            script
+        );
+    }
+
+    #[tokio::test]
+    async fn kind_transition_materialized_to_regular_use_drop_true() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut from_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        from_view.is_materialized = true;
+        from_view.hash();
+        from_dump.views.push(from_view);
+
+        let mut to_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        to_view.is_materialized = false;
+        to_view.hash();
+        to_dump.views.push(to_view);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        comparer.create_views().await.unwrap();
+        let script = comparer.get_script();
+
+        // DROP MATERIALIZED VIEW should be active
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop materialized view"));
+        assert!(
+            has_active_drop,
+            "Mat→regular: DROP MATERIALIZED VIEW should be active when use_drop=true, script:\n{}",
+            script
+        );
+        // CREATE OR REPLACE VIEW should be active
+        let has_active_create = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("create or replace view"));
+        assert!(
+            has_active_create,
+            "Mat→regular: CREATE OR REPLACE VIEW should be active when use_drop=true, script:\n{}",
+            script
+        );
+    }
+
+    #[tokio::test]
+    async fn kind_transition_materialized_to_regular_use_drop_false() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut from_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        from_view.is_materialized = true;
+        from_view.hash();
+        from_dump.views.push(from_view);
+
+        let mut to_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        to_view.is_materialized = false;
+        to_view.hash();
+        to_dump.views.push(to_view);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        comparer.create_views().await.unwrap();
+        let script = comparer.get_script();
+
+        // DROP should be commented
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop materialized view"));
+        assert!(
+            !has_active_drop,
+            "Mat→regular: DROP MATERIALIZED VIEW should be commented when use_drop=false, script:\n{}",
+            script
+        );
+        // CREATE OR REPLACE VIEW should also be commented (kind transition)
+        let has_active_create = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("create or replace view"));
+        assert!(
+            !has_active_create,
+            "Mat→regular: CREATE OR REPLACE VIEW should be commented when use_drop=false, script:\n{}",
+            script
+        );
+        assert!(
+            script.contains("manual intervention needed"),
+            "Should contain manual intervention warning, script:\n{}",
+            script
         );
     }
 }

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2493,11 +2493,13 @@ impl Comparer {
         // --- Views ---
         for view in &self.to.views {
             let normalized_key = Self::normalized_view_key(&view.schema, &view.name);
-            // When a view was dropped earlier in the script (e.g. as a
-            // dependency of an altered table), its ACL will be lost after
+            // When a view was actively dropped earlier in the script (e.g. as
+            // a dependency of an altered table), its ACL will be lost after
             // the DROP.  Treat from_acl as empty so that all required
-            // grants are emitted in the migration script.
-            let (from_acl, from_owner) = if self.dropped_views.contains_key(&normalized_key) {
+            // grants are emitted in the migration script.  When the drop
+            // was only commented out (use_drop=false), the view still
+            // exists so we must keep the original ACL for correct diffs.
+            let (from_acl, from_owner) = if self.dropped_views.get(&normalized_key) == Some(&true) {
                 (&[] as &[String], "")
             } else {
                 from_view_map
@@ -5861,6 +5863,59 @@ mod tests {
         assert!(
             script.contains("GRANT SELECT ON TABLE public.my_view TO reader;"),
             "Dropped view must restore grants even when FROM has the same ACL, got: {script}"
+        );
+    }
+
+    /// When a view's DROP was only commented out (use_drop=false), the view still
+    /// exists in the database.  compare_grants must keep the original from_acl so
+    /// that identical ACLs produce no diff (no redundant GRANTs/REVOKEs).
+    #[tokio::test]
+    async fn compare_grants_commented_drop_keeps_from_acl() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let mut from_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            Vec::new(),
+        );
+        from_view.acl = vec!["reader=r/owner".to_string()];
+
+        let mut to_view = View::new(
+            "my_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            Vec::new(),
+        );
+        to_view.acl = vec!["reader=r/owner".to_string()];
+
+        from_dump.views.push(from_view);
+        to_dump.views.push(to_view);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Full);
+        // Simulate a commented-out drop (use_drop=false → stored as false).
+        comparer
+            .dropped_views
+            .insert(Comparer::normalized_view_key("public", "my_view"), false);
+        comparer.compare_grants().await.unwrap();
+        let script = comparer.get_script();
+
+        // ACLs are identical and the view was NOT actually dropped,
+        // so no GRANT/REVOKE should appear.
+        let has_grant_stmt = script
+            .lines()
+            .any(|l| l.trim_start().to_lowercase().starts_with("grant "));
+        assert!(
+            !has_grant_stmt,
+            "Commented-out drop must not cause redundant GRANTs, got: {script}"
+        );
+        let has_revoke_stmt = script
+            .lines()
+            .any(|l| l.trim_start().to_lowercase().starts_with("revoke "));
+        assert!(
+            !has_revoke_stmt,
+            "Commented-out drop must not cause redundant REVOKEs, got: {script}"
         );
     }
 

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1957,10 +1957,10 @@ impl Comparer {
                     }
                 }
                 if was_dropped && !drop_was_active {
-                    // Kind transition (mat→regular): DROP was commented, so
-                    // CREATE OR REPLACE VIEW would fail; comment it out too.
+                    // DROP was commented out (for example, because use_drop=false),
+                    // so CREATE OR REPLACE VIEW would fail; comment it out too.
                     self.script.push_str(&format!(
-                        "-- use_drop=false: view {}.{} requires drop+recreate (kind transition); create commented out (manual intervention needed)\n",
+                        "-- use_drop=false: DROP for view {}.{} was commented out, so create is also commented out because it would fail (manual intervention needed)\n",
                         to_view.schema, to_view.name
                     ));
                     self.script.push_str(

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1095,7 +1095,8 @@ impl Comparer {
                     self.script.push_str(
                         format!("/* Sequence: {}.{}*/\n", sequence.schema, sequence.name).as_str(),
                     );
-                    self.script.push_str(sequence.get_alter_script().as_str());
+                    self.script
+                        .push_str(sequence.get_alter_script(from_sequence).as_str());
                 }
             } else {
                 // Check if the sequence is owned by a column that is an identity column or serial type.
@@ -3632,6 +3633,185 @@ mod tests {
         let script = comparer.get_script();
 
         assert!(script.contains("alter sequence public.test_seq owner to new_owner;"));
+    }
+
+    /// When MINVALUE is raised above the sequence's effective current position (last_value if
+    /// known, otherwise old start_value), the comparer must emit RESTART WITH so PostgreSQL does
+    /// not fall back to an old recorded start value that violates the new MINVALUE:
+    ///
+    ///   ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)
+    #[tokio::test]
+    async fn compare_sequences_emits_restart_when_effective_current_below_new_minvalue() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        // last_value is None → effective_current falls back to start_value (1), which is < 10M.
+        let from_sequence = Sequence::new(
+            "my_schema".to_string(),
+            "my_sequence_id_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1),
+            Some(1),
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "my_schema".to_string(),
+            "my_sequence_id_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(10_000_000),
+            Some(10_000_000),
+            Some(999_999_999),
+            Some(1),
+            true,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        from_dump.sequences.push(from_sequence);
+        to_dump.sequences.push(to_sequence);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.compare_sequences().await.unwrap();
+        let script = comparer.get_script();
+
+        assert!(
+            script.contains("start with 10000000"),
+            "script must contain START WITH: {script}"
+        );
+        assert!(
+            script.contains("restart with 10000000"),
+            "script must contain RESTART WITH to prevent RESTART value < MINVALUE error: {script}"
+        );
+    }
+
+    /// When last_value is already above the new MINVALUE, RESTART WITH must NOT be emitted
+    /// even though start_value and MINVALUE are both raised.  Emitting it would rewind the
+    /// live sequence and risk duplicate-key violations.
+    #[tokio::test]
+    async fn compare_sequences_no_restart_when_last_value_already_above_new_minvalue() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let from_sequence = Sequence::new(
+            "public".to_string(),
+            "busy_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1),
+            Some(1),
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            Some(15_000_000), // last_value is already well above the new MINVALUE (10M)
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "public".to_string(),
+            "busy_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(10_000_000), // start_value raised
+            Some(10_000_000), // MINVALUE raised — but last_value (15M) already satisfies it
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        from_dump.sequences.push(from_sequence);
+        to_dump.sequences.push(to_sequence);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.compare_sequences().await.unwrap();
+        let script = comparer.get_script();
+
+        assert!(
+            !script.contains("restart with"),
+            "script must NOT contain RESTART WITH when last_value is already above new MINVALUE: {script}"
+        );
+        assert!(
+            script.contains("alter sequence public.busy_seq"),
+            "script must still emit ALTER SEQUENCE to update start_value/minvalue: {script}"
+        );
+    }
+
+    /// When only non-start/minvalue parameters change (here: cycle) and the effective current
+    /// position is already within the new bounds, RESTART WITH must NOT be emitted.
+    #[tokio::test]
+    async fn compare_sequences_no_restart_when_only_other_params_change() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let mut to_dump = Dump::new(DumpConfig::default());
+
+        let from_sequence = Sequence::new(
+            "public".to_string(),
+            "live_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1),
+            Some(1),
+            Some(9999),
+            Some(1),
+            false, // cycle was false
+            Some(1),
+            Some(500_000),
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "public".to_string(),
+            "live_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1), // start_value unchanged
+            Some(1),
+            Some(9999),
+            Some(1),
+            true, // only cycle changed
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        from_dump.sequences.push(from_sequence);
+        to_dump.sequences.push(to_sequence);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.compare_sequences().await.unwrap();
+        let script = comparer.get_script();
+
+        assert!(
+            !script.contains("restart with"),
+            "script must NOT contain RESTART WITH when start_value is unchanged: {script}"
+        );
+        assert!(
+            script.contains("alter sequence public.live_seq"),
+            "script must still contain the ALTER SEQUENCE: {script}"
+        );
     }
 
     #[tokio::test]

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1793,10 +1793,8 @@ impl Comparer {
                 .map(|tv| from_view.is_materialized != tv.is_materialized)
                 .unwrap_or(false);
 
-            let should_drop = is_dependent
-                || (self.use_drop && is_from_only)
-                || is_changed_mat_view
-                || is_kind_transition;
+            let should_drop =
+                is_dependent || is_from_only || is_changed_mat_view || is_kind_transition;
 
             if should_drop {
                 // The drop is emitted as active SQL only when use_drop is true.
@@ -7491,6 +7489,77 @@ mod tests {
         assert!(
             script.contains("manual intervention needed"),
             "Should contain manual intervention warning, script:\n{}",
+            script
+        );
+    }
+
+    /// FROM-only views (present in FROM, absent in TO) must still appear in the output
+    /// when use_drop=false — as a commented-out DROP statement so the user is aware the
+    /// view should be removed.  Previously `should_drop` gated `is_from_only` behind
+    /// `self.use_drop`, which suppressed the DROP entirely.
+    #[tokio::test]
+    async fn from_only_view_commented_drop_when_use_drop_false() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let to_dump = Dump::new(DumpConfig::default());
+
+        let mut view = View::new(
+            "obsolete_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        view.is_materialized = false;
+        view.hash();
+        from_dump.views.push(view);
+
+        let mut comparer =
+            Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        let script = comparer.get_script();
+
+        // The DROP must appear in the output …
+        assert!(
+            script.to_lowercase().contains("drop view"),
+            "FROM-only view must produce a DROP statement even with use_drop=false, script:\n{}",
+            script
+        );
+        // … but it must be commented out, not active SQL.
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop view"));
+        assert!(
+            !has_active_drop,
+            "FROM-only view DROP should be commented when use_drop=false, script:\n{}",
+            script
+        );
+    }
+
+    /// Counterpart: with use_drop=true the DROP for a FROM-only view must be active SQL.
+    #[tokio::test]
+    async fn from_only_view_active_drop_when_use_drop_true() {
+        let mut from_dump = Dump::new(DumpConfig::default());
+        let to_dump = Dump::new(DumpConfig::default());
+
+        let mut view = View::new(
+            "obsolete_view".to_string(),
+            "SELECT 1".to_string(),
+            "public".to_string(),
+            vec![],
+        );
+        view.is_materialized = false;
+        view.hash();
+        from_dump.views.push(view);
+
+        let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+        comparer.drop_views().await.unwrap();
+        let script = comparer.get_script();
+
+        let has_active_drop = script
+            .lines()
+            .any(|l| !l.starts_with("--") && l.to_lowercase().contains("drop view"));
+        assert!(
+            has_active_drop,
+            "FROM-only view DROP should be active SQL when use_drop=true, script:\n{}",
             script
         );
     }

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2028,10 +2028,10 @@ impl Comparer {
                 .unwrap_or(true);
             let was_dropped = self.dropped_views.contains_key(&normalized_view);
             if was_dropped && !drop_was_active {
-                // Kind transition (mat→regular): DROP was commented, so
-                // CREATE OR REPLACE VIEW would fail; comment it out too.
+                // DROP was commented out, so CREATE OR REPLACE VIEW would fail;
+                // comment it out too.
                 self.script.push_str(&format!(
-                    "-- use_drop=false: view {}.{} requires drop+recreate (kind transition); create commented out (manual intervention needed)\n",
+                    "-- use_drop=false: view {}.{} requires drop+recreate; create commented out (manual intervention needed)\n",
                     to_view.schema, to_view.name
                 ));
                 self.script.push_str(

--- a/app/src/dump/pg_type.rs
+++ b/app/src/dump/pg_type.rs
@@ -408,7 +408,7 @@ impl PgType {
     }
 
     /// Returns a string to alter the existing user-defined type to match the target definition.
-    pub fn get_alter_script(&self, target: &PgType) -> String {
+    pub fn get_alter_script(&self, target: &PgType, use_drop: bool) -> String {
         if self.schema != target.schema || self.typname != target.typname {
             return format!(
                 "-- Cannot alter type {}.{} because target is {}.{}\n",
@@ -507,10 +507,15 @@ impl PgType {
                             self.schema, self.typname, default
                         ));
                     } else {
-                        statements.push(format!(
+                        let drop_cmd = format!(
                             "alter domain {}.{} drop default;",
                             self.schema, self.typname
-                        ));
+                        );
+                        if use_drop {
+                            statements.push(drop_cmd);
+                        } else {
+                            statements.push(format!("-- {}", drop_cmd));
+                        }
                     }
                 }
 
@@ -521,10 +526,15 @@ impl PgType {
                             self.schema, self.typname
                         ));
                     } else {
-                        statements.push(format!(
+                        let drop_cmd = format!(
                             "alter domain {}.{} drop not null;",
                             self.schema, self.typname
-                        ));
+                        );
+                        if use_drop {
+                            statements.push(drop_cmd);
+                        } else {
+                            statements.push(format!("-- {}", drop_cmd));
+                        }
                     }
                 }
 
@@ -544,29 +554,45 @@ impl PgType {
                     match target_constraints.get(name) {
                         Some(target_constraint) => {
                             if current_constraint.definition != target_constraint.definition {
-                                statements.push(format!(
+                                let drop_cmd = format!(
                                     "alter domain {}.{} drop constraint {};",
                                     self.schema,
                                     self.typname,
                                     quote_ident(name)
-                                ));
-                                statements.push(format!(
+                                );
+                                let add_cmd = format!(
                                     "alter domain {}.{} add constraint {} {};",
                                     self.schema,
                                     self.typname,
                                     quote_ident(name),
                                     target_constraint.definition
-                                ));
+                                );
+                                if use_drop {
+                                    statements.push(drop_cmd);
+                                    statements.push(add_cmd);
+                                } else {
+                                    statements.push(format!(
+                                        "-- use_drop=false: constraint {} requires drop+add; statements commented out (manual intervention needed)",
+                                        quote_ident(name)
+                                    ));
+                                    statements.push(format!("-- {}", drop_cmd));
+                                    statements.push(format!("-- {}", add_cmd));
+                                }
                                 replaced_or_added.insert((*name).to_string());
                             }
                         }
                         None => {
-                            statements.push(format!(
+                            let drop_cmd = format!(
                                 "alter domain {}.{} drop constraint {};",
                                 self.schema,
                                 self.typname,
                                 quote_ident(name)
-                            ));
+                            );
+                            if use_drop {
+                                statements.push(drop_cmd);
+                            } else {
+                                statements.push(format!("-- {}", drop_cmd));
+                            }
                         }
                     }
                 }
@@ -804,7 +830,7 @@ alter domain public.amount add constraint \"ValueCheck\" check (value > 0);\n\n"
             "completed".to_string(),
         ];
 
-        let script = current.get_alter_script(&target);
+        let script = current.get_alter_script(&target, true);
 
         assert_eq!(
             script,
@@ -818,7 +844,7 @@ alter domain public.amount add constraint \"ValueCheck\" check (value > 0);\n\n"
         current.enum_labels = vec!["pending".to_string(), "completed".to_string()];
         let target = current.clone();
 
-        let script = current.get_alter_script(&target);
+        let script = current.get_alter_script(&target, true);
 
         assert_eq!(script, "-- Enum public.my_type requires no changes.\n");
     }
@@ -849,7 +875,7 @@ alter domain public.amount add constraint \"ValueCheck\" check (value > 0);\n\n"
             },
         ];
 
-        let script = current.get_alter_script(&target);
+        let script = current.get_alter_script(&target, true);
 
         let expected = "alter domain public.amount set default 84;\n\n\
 alter domain public.amount drop not null;\n\n\
@@ -901,8 +927,234 @@ alter domain public.amount add constraint \"FreshConstraint\" check (value <> 0)
         let mut target = current.clone();
         target.owner = "new_owner".to_string();
 
-        let script = current.get_alter_script(&target);
+        let script = current.get_alter_script(&target, true);
 
         assert!(script.contains("alter type public.status owner to new_owner;"));
+    }
+
+    #[test]
+    fn get_alter_script_domain_drop_default_use_drop_false() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.typdefault = Some("42".to_string());
+
+        let mut target = current.clone();
+        target.typdefault = None;
+
+        let script = current.get_alter_script(&target, false);
+
+        assert!(script.contains("drop default"));
+        // The drop default line should be commented out
+        for line in script.lines() {
+            if line.contains("drop default") {
+                assert!(
+                    line.starts_with("--"),
+                    "drop default should be commented: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_drop_default_use_drop_true() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.typdefault = Some("42".to_string());
+
+        let mut target = current.clone();
+        target.typdefault = None;
+
+        let script = current.get_alter_script(&target, true);
+
+        assert!(script.contains("alter domain public.amount drop default;"));
+        // Should NOT be commented out
+        for line in script.lines() {
+            if line.contains("drop default") {
+                assert!(
+                    !line.starts_with("--"),
+                    "drop default should be active: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_drop_not_null_use_drop_false() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.typnotnull = true;
+
+        let mut target = current.clone();
+        target.typnotnull = false;
+
+        let script = current.get_alter_script(&target, false);
+
+        assert!(script.contains("drop not null"));
+        for line in script.lines() {
+            if line.contains("drop not null") {
+                assert!(
+                    line.starts_with("--"),
+                    "drop not null should be commented: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_drop_not_null_use_drop_true() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.typnotnull = true;
+
+        let mut target = current.clone();
+        target.typnotnull = false;
+
+        let script = current.get_alter_script(&target, true);
+
+        assert!(script.contains("alter domain public.amount drop not null;"));
+        for line in script.lines() {
+            if line.contains("drop not null") {
+                assert!(
+                    !line.starts_with("--"),
+                    "drop not null should be active: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_drop_constraint_use_drop_false() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.domain_constraints = vec![DomainConstraint {
+            name: "ValueCheck".to_string(),
+            definition: "check (value > 0)".to_string(),
+        }];
+
+        let mut target = current.clone();
+        target.domain_constraints = vec![DomainConstraint {
+            name: "ValueCheck".to_string(),
+            definition: "check (value >= 0)".to_string(),
+        }];
+
+        let script = current.get_alter_script(&target, false);
+
+        // Should contain a warning about manual intervention
+        assert!(
+            script.contains("use_drop=false") && script.contains("manual intervention needed"),
+            "should contain a warning comment, script:\n{}",
+            script
+        );
+
+        // Both drop and add constraint should be commented out
+        for line in script.lines() {
+            if line.contains("drop constraint") || line.contains("add constraint") {
+                assert!(line.starts_with("--"), "should be commented: {}", line);
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_remove_constraint_use_drop_false() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.domain_constraints = vec![DomainConstraint {
+            name: "OldCheck".to_string(),
+            definition: "check (value > 0)".to_string(),
+        }];
+
+        let mut target = current.clone();
+        target.domain_constraints = vec![];
+
+        let script = current.get_alter_script(&target, false);
+
+        assert!(script.contains("drop constraint"));
+        for line in script.lines() {
+            if line.contains("drop constraint") {
+                assert!(
+                    line.starts_with("--"),
+                    "drop constraint should be commented: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_alter_script_domain_all_drops_use_drop_false() {
+        let mut current = base_pg_type('d');
+        current.typname = "amount".to_string();
+        current.formatted_basetype = Some("integer".to_string());
+        current.typdefault = Some("42".to_string());
+        current.typnotnull = true;
+        current.domain_constraints = vec![DomainConstraint {
+            name: "ValueCheck".to_string(),
+            definition: "check (value > 0)".to_string(),
+        }];
+
+        let mut target = current.clone();
+        target.typdefault = Some("84".to_string());
+        target.typnotnull = false;
+        target.domain_constraints = vec![
+            DomainConstraint {
+                name: "ValueCheck".to_string(),
+                definition: "check (value >= 0)".to_string(),
+            },
+            DomainConstraint {
+                name: "FreshConstraint".to_string(),
+                definition: "check (value <> 0)".to_string(),
+            },
+        ];
+
+        let script = current.get_alter_script(&target, false);
+
+        // set default should still be active (not a drop)
+        assert!(script.contains("set default 84"));
+        // drop not null should be commented
+        for line in script.lines() {
+            if line.contains("drop not null") {
+                assert!(
+                    line.starts_with("--"),
+                    "drop not null should be commented: {}",
+                    line
+                );
+            }
+        }
+        // drop constraint should be commented
+        for line in script.lines() {
+            if line.contains("drop constraint") {
+                assert!(
+                    line.starts_with("--"),
+                    "drop constraint should be commented: {}",
+                    line
+                );
+            }
+        }
+        // add constraint for changed constraint should also be commented (depends on drop)
+        // but add constraint for new constraint should be active
+        assert!(
+            script.contains("-- use_drop=false: constraint \"ValueCheck\""),
+            "should warn about ValueCheck requiring manual intervention"
+        );
+        // FreshConstraint is brand new, its add should be active
+        for line in script.lines() {
+            if line.contains("add constraint") && line.contains("FreshConstraint") {
+                assert!(
+                    !line.starts_with("--"),
+                    "new constraint add should be active: {}",
+                    line
+                );
+            }
+        }
     }
 }

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -512,7 +512,10 @@ impl Routine {
         if !current.is_empty() {
             parts.push(current);
         }
-        debug_assert!(!in_quote, "split_arguments: unclosed single-quote in input: {s:?}");
+        debug_assert!(
+            !in_quote,
+            "split_arguments: unclosed single-quote in input: {s:?}"
+        );
         parts
     }
 
@@ -1236,7 +1239,8 @@ mod tests {
         // A multiline JSONB literal (containing newlines inside the quoted string)
         // must be treated as a single argument — newlines and commas inside the
         // single-quoted literal must not trigger a split.
-        let input = "p jsonb DEFAULT '{\n    \"key1\": \"value1\",\n    \"key2\": \"value2\"\n}'::jsonb";
+        let input =
+            "p jsonb DEFAULT '{\n    \"key1\": \"value1\",\n    \"key2\": \"value2\"\n}'::jsonb";
         let result = Routine::split_arguments(input);
         assert_eq!(result, vec![input]);
     }

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -450,15 +450,48 @@ impl Routine {
         result_parts.join(", ")
     }
 
-    /// Splits a comma-separated string respecting parenthesized groups.
-    /// E.g. "a numeric(10,2), b text" → ["a numeric(10,2)", " b text"]
+    /// Splits a comma-separated string respecting parenthesized groups and
+    /// single-quoted string literals.
+    /// E.g. "a numeric(10,2), b text"    → ["a numeric(10,2)", " b text"]
+    /// E.g. "','::character varying, 0"  → ["','::character varying", " 0"]
+    ///
+    /// Dollar-quoted strings (`$$...$$`) are intentionally not handled: both
+    /// call sites receive output from `pg_get_function_identity_arguments` or
+    /// `pg_get_expr(proargdefaults, 0)`, which always produce single-quoted
+    /// expressions and never emit dollar-quotes.
     fn split_arguments(s: &str) -> Vec<String> {
         let mut parts = Vec::new();
         let mut depth = 0;
+        let mut in_quote = false;
         let mut current = String::new();
+        let mut iter = s.chars().peekable();
 
-        for ch in s.chars() {
+        while let Some(ch) = iter.next() {
+            if in_quote {
+                // Inside a single-quoted string literal.
+                // Two consecutive single quotes represent an escaped quote ('').
+                if ch == '\'' {
+                    if iter.peek() == Some(&'\'') {
+                        // Escaped quote: consume both characters and stay in-quote.
+                        current.push('\'');
+                        current.push(iter.next().unwrap()); // safe: peek() confirmed Some above
+                    } else {
+                        // Closing quote.
+                        in_quote = false;
+                        current.push(ch);
+                    }
+                } else {
+                    current.push(ch);
+                }
+                continue;
+            }
+
+            // Outside any string literal.
             match ch {
+                '\'' => {
+                    in_quote = true;
+                    current.push(ch);
+                }
                 '(' => {
                     depth += 1;
                     current.push(ch);
@@ -468,8 +501,7 @@ impl Routine {
                     current.push(ch);
                 }
                 ',' if depth == 0 => {
-                    parts.push(current.clone());
-                    current.clear();
+                    parts.push(std::mem::take(&mut current));
                 }
                 _ => {
                     current.push(ch);
@@ -480,7 +512,7 @@ impl Routine {
         if !current.is_empty() {
             parts.push(current);
         }
-
+        debug_assert!(!in_quote, "split_arguments: unclosed single-quote in input: {s:?}");
         parts
     }
 
@@ -1129,6 +1161,132 @@ mod tests {
             script.contains("create aggregate public.my_mode(ORDER BY anyelement)"),
             "Expected ordered-set syntax with no direct args, got: {}",
             script
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // split_arguments: single-quote handling (Issue #154)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn split_arguments_respects_single_quoted_comma() {
+        // A single default value whose expression contains a comma inside quotes.
+        let input = "','::character varying";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["','::character varying"]);
+    }
+
+    #[test]
+    fn split_arguments_multiple_defaults_with_quoted_comma() {
+        // Two defaults: the first contains a quoted comma, the second is a plain number.
+        let input = "','::character varying, 0";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["','::character varying", " 0"]);
+    }
+
+    #[test]
+    fn split_arguments_escaped_quotes() {
+        // Two defaults: the first uses escaped single-quotes ('' inside a string).
+        let input = "'''hello'''::text, 42";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["'''hello'''::text", " 42"]);
+    }
+
+    #[test]
+    fn split_arguments_parenthesized_still_works() {
+        // Existing behaviour: parenthesised type expressions must not be split.
+        let input = "a numeric(10,2), b text";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec!["a numeric(10,2)", " b text"]);
+    }
+
+    // -----------------------------------------------------------------
+    // split_arguments: JSONB default with commas (Issue #154)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn split_arguments_jsonb_default_with_commas() {
+        // A JSONB literal default containing multiple comma-separated key-value
+        // pairs must not be split into multiple arguments.
+        let input = r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#;
+        let result = Routine::split_arguments(input);
+        assert_eq!(
+            result,
+            vec![r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#]
+        );
+    }
+
+    #[test]
+    fn split_arguments_jsonb_default_multiple_args() {
+        // JSONB default alongside other arguments: only the top-level comma
+        // (outside the single-quoted literal) must be treated as a delimiter.
+        let input = r#"id integer, opts jsonb DEFAULT '{"a": 1, "b": 2}'::jsonb"#;
+        let result = Routine::split_arguments(input);
+        assert_eq!(
+            result,
+            vec![
+                "id integer",
+                r#" opts jsonb DEFAULT '{"a": 1, "b": 2}'::jsonb"#
+            ]
+        );
+    }
+
+    #[test]
+    fn split_arguments_jsonb_default_multiline() {
+        // A multiline JSONB literal (containing newlines inside the quoted string)
+        // must be treated as a single argument — newlines and commas inside the
+        // single-quoted literal must not trigger a split.
+        let input = "p jsonb DEFAULT '{\n    \"key1\": \"value1\",\n    \"key2\": \"value2\"\n}'::jsonb";
+        let result = Routine::split_arguments(input);
+        assert_eq!(result, vec![input]);
+    }
+
+    #[test]
+    fn arguments_with_defaults_jsonb_default() {
+        // Full round-trip for Issue #154: a function with a multi-key JSONB
+        // default must reconstruct the full default without splitting on the
+        // commas inside the quoted literal.
+        let routine = Routine::new(
+            "test_schema".to_string(),
+            Oid(400),
+            "foo".to_string(),
+            "plpgsql".to_string(),
+            "FUNCTION".to_string(),
+            "void".to_string(),
+            "p jsonb".to_string(),
+            Some(r#"'{"key1": "value1", "key2": "value2"}'::jsonb"#.to_string()),
+            None,
+            "BEGIN END".to_string(),
+        );
+
+        let result = routine.arguments_with_defaults();
+        assert_eq!(
+            result,
+            r#"p jsonb DEFAULT '{"key1": "value1", "key2": "value2"}'::jsonb"#
+        );
+    }
+
+    #[test]
+    fn arguments_with_defaults_comma_default() {
+        // Full round-trip: a procedure with two varchar params where only the
+        // second has a default of ','::character varying.
+        let routine = Routine::new(
+            "test_schema".to_string(),
+            Oid(300),
+            "format_csv_line".to_string(),
+            "plpgsql".to_string(),
+            "PROCEDURE".to_string(),
+            "void".to_string(),
+            "p_value character varying, p_delimiter character varying".to_string(),
+            Some("','::character varying".to_string()),
+            None,
+            "BEGIN RAISE NOTICE '%', p_value || p_delimiter; END".to_string(),
+        );
+
+        let result = routine.arguments_with_defaults();
+        assert_eq!(
+            result,
+            "p_value character varying, p_delimiter character varying DEFAULT ','::character varying"
         );
     }
 }

--- a/app/src/dump/sequence.rs
+++ b/app/src/dump/sequence.rs
@@ -196,12 +196,36 @@ impl Sequence {
         format!("drop sequence if exists {}.{};", self.schema, self.name).with_empty_lines()
     }
 
-    pub fn get_alter_script(&self) -> String {
+    /// Generates an ALTER SEQUENCE script targeting `self` (the desired state).
+    ///
+    /// `from` is the prior sequence state (always required — callers that own the comparer
+    /// always have it).  `RESTART WITH` is emitted only when the sequence's effective current
+    /// position would fall below the new `MINVALUE`, i.e. when
+    /// `effective_current < new_minvalue` where
+    /// `effective_current = from.last_value ?? from.start_value`.
+    ///
+    /// This is the minimal condition required to prevent PostgreSQL from rejecting the
+    /// statement with:
+    ///
+    ///   ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)
+    ///
+    /// Emitting `RESTART WITH` unconditionally (e.g. whenever `start_value` differs)
+    /// would rewind a live sequence whose current position is already above the new
+    /// `start_value`, risking duplicate-key violations.
+    pub fn get_alter_script(&self, from: &Sequence) -> String {
         let mut clauses = Vec::new();
 
         if let Some(start_value) = self.start_value {
-            // Use START WITH to update the catalog start_value; this avoids re-emitting the diff.
             clauses.push(format!("start with {start_value}"));
+            // Emit RESTART WITH only when the effective current position (last_value if
+            // available, otherwise old start_value) lies below the new MINVALUE.  Any other
+            // restart would risk rewinding a live sequence.
+            if let Some(new_minvalue) = self.min_value {
+                let effective_current = from.last_value.or(from.start_value).unwrap_or(start_value);
+                if effective_current < new_minvalue {
+                    clauses.push(format!("restart with {start_value}"));
+                }
+            }
         }
         if let Some(increment_by) = self.increment_by {
             clauses.push(format!("increment by {increment_by}"));
@@ -360,8 +384,9 @@ mod tests {
     fn test_get_alter_script_includes_owned_by() {
         let sequence = build_sequence();
 
+        // start_value unchanged (from == to == 1): no RESTART WITH expected.
         assert_eq!(
-            sequence.get_alter_script(),
+            sequence.get_alter_script(&sequence.clone()),
             "alter sequence public.order_id_seq start with 1 increment by 5 minvalue 1 maxvalue 1000 cache 20 cycle owned by public.orders.id;\n\nalter sequence public.order_id_seq owner to postgres;\n\n",
         );
     }
@@ -385,9 +410,168 @@ mod tests {
             Some("column".to_string()),
         );
 
+        // start_value unchanged (from == to == 10): no RESTART WITH expected.
         assert_eq!(
-            sequence.get_alter_script(),
+            sequence.get_alter_script(&sequence.clone()),
             "alter sequence audit.event_seq start with 10 increment by 2 no minvalue no maxvalue no cycle owned by \"my\"\"schema\".\"my.table\".column;\n\nalter sequence audit.event_seq owner to postgres;\n\n",
+        );
+    }
+
+    /// Regression test: when MINVALUE is raised above the sequence's previously recorded start
+    /// value (e.g. 1), an ALTER SEQUENCE without RESTART WITH causes PostgreSQL to implicitly
+    /// restart from the old start value, which violates the new MINVALUE constraint:
+    ///
+    ///   ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)
+    ///
+    /// The generated script must include an explicit RESTART WITH equal to START WITH so that
+    /// the current sequence position is repositioned to the new value before the constraint
+    /// check is applied.
+    #[test]
+    fn test_get_alter_script_restart_with_matches_start_with_when_minvalue_raised() {
+        let from_sequence = Sequence::new(
+            "my_schema".to_string(),
+            "my_sequence_id_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1), // old start_value
+            Some(1),
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "my_schema".to_string(),
+            "my_sequence_id_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(10_000_000), // new start_value — also serves as the new MINVALUE
+            Some(10_000_000), // MINVALUE raised well above the old start value of 1
+            Some(999_999_999),
+            Some(1),
+            true,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let script = to_sequence.get_alter_script(&from_sequence);
+
+        // Both clauses must appear so that PostgreSQL does not fall back to the old start value.
+        assert!(
+            script.contains("start with 10000000"),
+            "script must contain START WITH: {script}"
+        );
+        assert!(
+            script.contains("restart with 10000000"),
+            "script must contain RESTART WITH to avoid RESTART value < MINVALUE error: {script}"
+        );
+        assert_eq!(
+            script,
+            "alter sequence my_schema.my_sequence_id_seq start with 10000000 restart with 10000000 increment by 1 minvalue 10000000 maxvalue 999999999 cache 1 cycle;\n\nalter sequence my_schema.my_sequence_id_seq owner to postgres;\n\n",
+        );
+    }
+
+    /// RESTART WITH must NOT be emitted when the sequence's effective current position
+    /// (last_value) is already above the new MINVALUE — even when start_value and MINVALUE are
+    /// both raised.  Emitting it would rewind the live sequence from its current position back
+    /// to the new start_value, risking duplicate-key violations.
+    #[test]
+    fn test_get_alter_script_no_restart_when_last_value_above_new_minvalue() {
+        let from_sequence = Sequence::new(
+            "public".to_string(),
+            "busy_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1),
+            Some(1),
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            Some(15_000_000), // sequence is already well above the new MINVALUE
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "public".to_string(),
+            "busy_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(10_000_000), // start_value raised
+            Some(10_000_000), // MINVALUE raised — but last_value (15M) is already above it
+            Some(999_999_999),
+            Some(1),
+            false,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let script = to_sequence.get_alter_script(&from_sequence);
+
+        assert!(
+            !script.contains("restart with"),
+            "script must NOT contain RESTART WITH when last_value ({}) is already above new MINVALUE (10000000): {script}",
+            15_000_000
+        );
+        assert!(
+            script.contains("start with 10000000"),
+            "script must still update START WITH: {script}"
+        );
+    }
+
+    /// When only non-start/minvalue parameters change (e.g. cycle) and the effective current
+    /// position is already within the new bounds, RESTART WITH must NOT be emitted.
+    #[test]
+    fn test_get_alter_script_no_restart_when_only_other_params_change() {
+        let from_sequence = Sequence::new(
+            "public".to_string(),
+            "live_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1),
+            Some(1),
+            Some(9999),
+            Some(1),
+            false, // cycle was false
+            Some(1),
+            Some(500_000), // current live position
+            None,
+            None,
+            None,
+        );
+        let to_sequence = Sequence::new(
+            "public".to_string(),
+            "live_seq".to_string(),
+            "postgres".to_string(),
+            "bigint".to_string(),
+            Some(1), // start_value unchanged
+            Some(1),
+            Some(9999),
+            Some(1),
+            true, // only cycle changed
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let script = to_sequence.get_alter_script(&from_sequence);
+
+        assert!(
+            !script.contains("restart with"),
+            "script must NOT contain RESTART WITH when start_value is unchanged: {script}"
         );
     }
 }

--- a/app/src/dump/table_column.rs
+++ b/app/src/dump/table_column.rs
@@ -439,13 +439,23 @@ impl TableColumn {
                     )
                     .with_empty_lines(),
                 ),
-                None => statements.push(
-                    format!(
+                None => {
+                    let drop_cmd = format!(
                         "alter table {}.{} alter column {} drop default;",
                         self.schema, self.table, self.name
                     )
-                    .with_empty_lines(),
-                ),
+                    .with_empty_lines();
+                    if use_drop {
+                        statements.push(drop_cmd);
+                    } else {
+                        statements.push(
+                            drop_cmd
+                                .lines()
+                                .map(|l| format!("-- {}\n", l))
+                                .collect::<String>(),
+                        );
+                    }
+                }
             }
         }
 
@@ -481,13 +491,21 @@ impl TableColumn {
             if self.is_identity {
                 statements.push(self.build_identity_add_statement(existing));
             } else {
-                statements.push(
-                    format!(
-                        "alter table {}.{} alter column {} drop identity if exists;",
-                        self.schema, self.table, self.name
-                    )
-                    .with_empty_lines(),
-                );
+                let drop_cmd = format!(
+                    "alter table {}.{} alter column {} drop identity if exists;",
+                    self.schema, self.table, self.name
+                )
+                .with_empty_lines();
+                if use_drop {
+                    statements.push(drop_cmd);
+                } else {
+                    statements.push(
+                        drop_cmd
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                    );
+                }
             }
         } else if self.is_identity {
             self.build_identity_update_statements(existing, &mut statements);
@@ -522,22 +540,42 @@ impl TableColumn {
                 }
             } else {
                 if old_is_generated {
-                    statements.push(
-                        format!(
-                            "alter table {}.{} alter column {} drop expression;",
-                            self.schema, self.table, self.name
-                        )
-                        .with_empty_lines(),
-                    );
+                    let drop_cmd = format!(
+                        "alter table {}.{} alter column {} drop expression;",
+                        self.schema, self.table, self.name
+                    )
+                    .with_empty_lines();
+                    if use_drop {
+                        statements.push(drop_cmd);
+                    } else {
+                        statements.push(
+                            drop_cmd
+                                .lines()
+                                .map(|l| format!("-- {}\n", l))
+                                .collect::<String>(),
+                        );
+                    }
                 }
 
                 if new_is_generated && let Some(expr) = &self.generation_expression {
                     let norm_expr = Self::normalized_generation_expression(expr);
                     let wrapped = format!("({norm_expr})");
-                    statements.push(format!(
+                    let add_cmd = format!(
                         "alter table {}.{} alter column {} add generated always as {wrapped} stored;",
                         self.schema, self.table, self.name
-                    ).with_empty_lines());
+                    ).with_empty_lines();
+                    if use_drop || !old_is_generated {
+                        statements.push(add_cmd);
+                    } else {
+                        // Drop was commented out, so add would fail; comment it out too
+                        statements.push("-- use_drop=false: drop expression + add generated requires drop; statements commented out (manual intervention needed)\n".to_string());
+                        statements.push(
+                            add_cmd
+                                .lines()
+                                .map(|l| format!("-- {}\n", l))
+                                .collect::<String>(),
+                        );
+                    }
                 }
             }
         }
@@ -1511,5 +1549,127 @@ mod tests {
             script,
             "alter table public.test_table alter column test_column drop expression;\n\n"
         );
+    }
+
+    #[test]
+    fn test_get_alter_script_drop_default_use_drop_false() {
+        let mut existing = create_test_column();
+        existing.column_default = Some("'old_default'".to_string());
+        let mut updated = existing.clone();
+        updated.column_default = None;
+
+        let script = updated
+            .get_alter_script(&existing, false)
+            .expect("expected commented drop default when use_drop is false");
+
+        assert!(script.contains("drop default"));
+        assert!(script.lines().all(|l| l.starts_with("--")));
+    }
+
+    #[test]
+    fn test_get_alter_script_drop_default_use_drop_true() {
+        let mut existing = create_test_column();
+        existing.column_default = Some("'old_default'".to_string());
+        let mut updated = existing.clone();
+        updated.column_default = None;
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("expected drop default when use_drop is true");
+
+        assert_eq!(
+            script,
+            "alter table public.test_table alter column test_column drop default;\n\n"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_drop_identity_use_drop_false() {
+        let mut existing = create_test_column();
+        existing.is_identity = true;
+        existing.identity_generation = Some("BY DEFAULT".to_string());
+        existing.identity_start = Some("1".to_string());
+        existing.identity_increment = Some("1".to_string());
+
+        let mut updated = existing.clone();
+        updated.is_identity = false;
+        updated.identity_generation = None;
+        updated.identity_start = None;
+        updated.identity_increment = None;
+
+        let script = updated
+            .get_alter_script(&existing, false)
+            .expect("expected commented drop identity when use_drop is false");
+
+        assert!(script.contains("drop identity if exists"));
+        assert!(script.lines().all(|l| l.starts_with("--")));
+    }
+
+    #[test]
+    fn test_get_alter_script_drop_identity_use_drop_true() {
+        let mut existing = create_test_column();
+        existing.is_identity = true;
+        existing.identity_generation = Some("BY DEFAULT".to_string());
+        existing.identity_start = Some("1".to_string());
+        existing.identity_increment = Some("1".to_string());
+
+        let mut updated = existing.clone();
+        updated.is_identity = false;
+        updated.identity_generation = None;
+        updated.identity_start = None;
+        updated.identity_increment = None;
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("expected drop identity when use_drop is true");
+
+        assert_eq!(
+            script,
+            "alter table public.test_table alter column test_column drop identity if exists;\n\n"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_drop_expression_use_drop_false() {
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+
+        let updated = create_test_column();
+
+        let script = updated
+            .get_alter_script(&existing, false)
+            .expect("expected commented drop expression when use_drop is false");
+
+        assert!(script.contains("drop expression"));
+        assert!(script.lines().all(|l| l.starts_with("--")));
+    }
+
+    #[test]
+    fn test_get_alter_script_update_generated_expression_use_drop_false() {
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+
+        let mut updated = existing.clone();
+        updated.generation_expression = Some("(id * 3)".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, false)
+            .expect("expected output when use_drop is false for expression update");
+
+        // Should contain a warning about manual intervention
+        assert!(
+            script.contains("use_drop=false") && script.contains("manual intervention needed"),
+            "should contain a warning comment, script:\n{}",
+            script
+        );
+
+        // Both drop expression and add generated should be commented out
+        for line in script.lines() {
+            if line.contains("drop expression") || line.contains("add generated always") {
+                assert!(line.starts_with("--"), "should be commented out: {}", line);
+            }
+        }
     }
 }

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -15,7 +15,7 @@ pub struct TableConstraint {
     pub initially_deferred: bool, // Whether the constraint is initially deferred
     pub definition: Option<String>, // Definition of the constraint (e.g., check expression)
     #[serde(default)]
-    pub coninhcount: i16, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
+    pub coninhcount: i32, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
 }
 
 impl TableConstraint {

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -15,7 +15,7 @@ pub struct TableConstraint {
     pub initially_deferred: bool, // Whether the constraint is initially deferred
     pub definition: Option<String>, // Definition of the constraint (e.g., check expression)
     #[serde(default)]
-    pub coninhcount: i32, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
+    pub coninhcount: i16, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
 }
 
 impl TableConstraint {

--- a/app/src/dump/view.rs
+++ b/app/src/dump/view.rs
@@ -135,7 +135,7 @@ impl View {
     }
 
     /// Returns a script that alters the current view to match the target definition.
-    pub fn get_alter_script(&self, target: &View) -> String {
+    pub fn get_alter_script(&self, target: &View, use_drop: bool) -> String {
         if self.schema != target.schema || self.name != target.name {
             return format!(
                 "-- Cannot alter view {}.{} because target is {}.{}\n",
@@ -155,9 +155,32 @@ impl View {
             );
         }
 
-        // Materialized views do not support CREATE OR REPLACE; drop and recreate instead.
-        if target.is_materialized {
-            return format!("{}{}", target.get_drop_script(), target.get_script());
+        // When the view kind changes (regular <-> materialized) or the target is
+        // a materialized view, we must drop and recreate because neither kind
+        // supports an in-place ALTER to the other, and materialized views do not
+        // support CREATE OR REPLACE.
+        let kind_changed = self.is_materialized != target.is_materialized;
+        if target.is_materialized || kind_changed {
+            // DROP must match the *current* object type so the existing object
+            // is actually removed.
+            let drop_script = self.get_drop_script();
+            if use_drop {
+                return format!("{}{}", drop_script, target.get_script());
+            } else {
+                let commented_drop = drop_script
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                let commented_create = target
+                    .get_script()
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                return format!(
+                    "-- use_drop=false: view {}.{} requires drop+recreate; statements commented out (manual intervention needed)\n{}{}",
+                    target.schema, target.name, commented_drop, commented_create
+                );
+            }
         }
 
         let script = target.get_script();
@@ -294,7 +317,7 @@ mod tests {
         target.definition = "select 1".to_string();
 
         assert_eq!(
-            view.get_alter_script(&target),
+            view.get_alter_script(&target, true),
             "-- View analytics.active_users requires no changes.\n"
         );
     }
@@ -310,7 +333,7 @@ mod tests {
         );
 
         assert_eq!(
-            view.get_alter_script(&target),
+            view.get_alter_script(&target, true),
             "-- Cannot alter view analytics.active_users because target is analytics.other\n"
         );
     }
@@ -321,7 +344,7 @@ mod tests {
         let replacement = create_view("create or replace view analytics.active_users as select 2");
 
         assert_eq!(
-            current.get_alter_script(&replacement),
+            current.get_alter_script(&replacement, true),
             "create view analytics.active_users as\ncreate or replace view analytics.active_users as select 2\n\n"
         );
     }
@@ -332,7 +355,7 @@ mod tests {
         let target = create_view("select id, active from public.users where active");
 
         assert_eq!(
-            current.get_alter_script(&target),
+            current.get_alter_script(&target, true),
             "CREATE OR REPLACE VIEW analytics.active_users AS\nselect id, active from public.users where active\n\n"
         );
     }
@@ -343,8 +366,138 @@ mod tests {
         let target = create_materialized_view("select id from public.users");
 
         assert_eq!(
-            current.get_alter_script(&target),
+            current.get_alter_script(&target, true),
             "drop materialized view if exists analytics.active_users;\n\ncreate materialized view analytics.active_users as\nselect id from public.users\n\n"
         );
+    }
+
+    #[test]
+    fn test_get_alter_script_materialized_use_drop_false() {
+        let current = create_materialized_view("select 1");
+        let target = create_materialized_view("select id from public.users");
+
+        let script = current.get_alter_script(&target, false);
+
+        // Should contain a warning about manual intervention
+        assert!(
+            script.contains("use_drop=false") && script.contains("manual intervention needed"),
+            "should contain a warning comment, script:\n{}",
+            script
+        );
+
+        // Both drop and create should be commented out
+        for line in script.lines() {
+            if line.contains("drop materialized view") || line.contains("create materialized view")
+            {
+                assert!(line.starts_with("--"), "should be commented: {}", line);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_alter_script_materialized_use_drop_true_contains_active_drop() {
+        let current = create_materialized_view("select 1");
+        let target = create_materialized_view("select id from public.users");
+
+        let script = current.get_alter_script(&target, true);
+
+        // The drop line should NOT be commented
+        for line in script.lines() {
+            if line.contains("drop materialized view") {
+                assert!(!line.starts_with("--"), "drop should be active: {}", line);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_alter_script_regular_view_unaffected_by_use_drop() {
+        let current = create_view("select 1");
+        let target = create_view("select id, active from public.users where active");
+
+        let with_drop = current.get_alter_script(&target, true);
+        let without_drop = current.get_alter_script(&target, false);
+
+        // Regular views use CREATE OR REPLACE, no drop involved
+        assert_eq!(with_drop, without_drop);
+        assert!(!with_drop.contains("drop"));
+    }
+
+    #[test]
+    fn test_get_alter_script_regular_to_materialized_drops_view() {
+        let current = create_view("select 1");
+        let target = create_materialized_view("select 1");
+
+        let script = current.get_alter_script(&target, true);
+
+        // DROP must target the current kind (regular view), not the target kind
+        assert!(
+            script.contains("drop view if exists"),
+            "should drop the regular view, script:\n{}",
+            script
+        );
+        assert!(
+            !script.contains("drop materialized view"),
+            "should NOT emit DROP MATERIALIZED VIEW for a regular view"
+        );
+        // Then create the materialized view
+        assert!(script.contains("create materialized view"));
+    }
+
+    #[test]
+    fn test_get_alter_script_materialized_to_regular_drops_materialized() {
+        let current = create_materialized_view("select 1");
+        let target = create_view("select 1");
+
+        let script = current.get_alter_script(&target, true);
+
+        // DROP must target the current kind (materialized view)
+        assert!(
+            script.contains("drop materialized view if exists"),
+            "should drop the materialized view, script:\n{}",
+            script
+        );
+        // Then create the regular view
+        assert!(script.contains("create view"));
+    }
+
+    #[test]
+    fn test_get_alter_script_regular_to_materialized_use_drop_false() {
+        let current = create_view("select 1");
+        let target = create_materialized_view("select 1");
+
+        let script = current.get_alter_script(&target, false);
+
+        assert!(
+            script.contains("use_drop=false") && script.contains("manual intervention needed"),
+            "should warn about manual intervention, script:\n{}",
+            script
+        );
+
+        // Both drop and create should be commented out
+        for line in script.lines() {
+            if line.contains("drop view") || line.contains("create materialized view") {
+                assert!(line.starts_with("--"), "should be commented: {}", line);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_alter_script_materialized_to_regular_use_drop_false() {
+        let current = create_materialized_view("select 1");
+        let target = create_view("select 1");
+
+        let script = current.get_alter_script(&target, false);
+
+        assert!(
+            script.contains("use_drop=false") && script.contains("manual intervention needed"),
+            "should warn about manual intervention, script:\n{}",
+            script
+        );
+
+        for line in script.lines() {
+            if line.contains("drop materialized view") || line.contains("create view") {
+                assert!(line.starts_with("--"), "should be commented: {}", line);
+            }
+        }
     }
 }

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -162,6 +162,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 #### Unchanged Procedures
 - **notify_event(uuid, varchar, jsonb)**: 3-param overload, identical in both schemas
 - **notify_event(uuid, varchar, varchar, jsonb, jsonb)**: 5-param overload, identical in both schemas (tests overloaded routine matching by argument signature)
+- **format_csv_line(varchar, varchar)**: procedure with a comma-in-string default (`DEFAULT ','`) - identical in both schemas; no diff should be emitted (Issue #154 regression test)
 
 ### 12. Triggers
 - **Added**: `trigger_reviews_update_timestamp`, `trigger_reviews_audit` on `reviews` table
@@ -263,6 +264,12 @@ Grant comparison test using roles `pgc_grant_reader` and `pgc_grant_writer`.
 #### Routine Dependency Ordering
 - View ↔ routine cross-dependencies: `get_user_count()` → `v_user_stats` → `report_user_stats()` / `print_user_stats()`
 - Routine chain: `r_base_value()` → `x_step_one()` → `a_middle_layer()` → `z_final_report()`
+
+#### Comma-in-String Default (Issue #154)
+- `test_schema.format_csv_line(p_value varchar, p_delimiter varchar DEFAULT ',')` is present and identical in both schemas
+- PostgreSQL stores the default separately via `pg_get_expr(proargdefaults, 0)`, which returns `','::character varying`
+- The comma inside the quoted string literal must not be treated as a delimiter when splitting the defaults string
+- The comparer must produce no diff for this procedure, confirming the round-trip is correct
 
 ---
 

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -41,6 +41,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 ### 4. Sequences
 - **Modified**: `test_schema.user_id_seq` — START changed from 1000 → 2000
 - **Modified**: `shared_schema.global_counter_seq` — CACHE changed from 1 → 5
+- **Modified**: `test_schema.minvalue_raise_seq` — START WITH and MINVALUE both raised from 1 → 10000000; NO CYCLE → CYCLE. The comparer must emit `RESTART WITH 10000000` alongside `START WITH 10000000` to prevent PostgreSQL from implicitly restarting from the old recorded start value (1), which would violate the new MINVALUE and produce: `ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)`
 - **Removed**: `test_schema.order_id_seq` in Schema B
 - **Added**: `new_reporting_schema.report_id_seq` in Schema B
 

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -377,8 +377,19 @@ BEGIN
     DELETE FROM test_schema.orders
     WHERE created_at < CURRENT_DATE - INTERVAL '1 day' * days_old
     AND status = 'delivered';
-    
+
     COMMIT;
+END;
+$$;
+
+-- Procedure with comma-in-string default (Issue #154 regression test)
+CREATE OR REPLACE PROCEDURE test_schema.format_csv_line(
+    p_value varchar,
+    p_delimiter varchar DEFAULT ','
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE NOTICE '%', p_value || p_delimiter;
 END;
 $$;
 

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -81,6 +81,17 @@ CREATE SEQUENCE shared_schema.global_counter_seq
     MAXVALUE 999999999
     CACHE 1;
 
+-- Sequence used to test MINVALUE raise: start/minvalue begin at 1 so that when Schema B
+-- raises both to 10000000 the comparer must emit RESTART WITH to avoid:
+--   ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)
+CREATE SEQUENCE test_schema.minvalue_raise_seq
+    START WITH 1
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 999999999
+    CACHE 1
+    NO CYCLE;
+
 -- Tables
 CREATE TABLE test_schema.users (
     id INTEGER PRIMARY KEY DEFAULT nextval('test_schema.user_id_seq'),

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -415,8 +415,19 @@ BEGIN
     DELETE FROM test_schema.reviews
     WHERE created_at < CURRENT_DATE - INTERVAL '1 day' * days_old
     AND helpful_count = 0;
-    
+
     COMMIT;
+END;
+$$;
+
+-- Procedure with comma-in-string default (Issue #154 regression test)
+CREATE OR REPLACE PROCEDURE test_schema.format_csv_line(
+    p_value varchar,
+    p_delimiter varchar DEFAULT ','
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE NOTICE '%', p_value || p_delimiter;
 END;
 $$;
 

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -86,6 +86,18 @@ CREATE SEQUENCE shared_schema.global_counter_seq
     MAXVALUE 999999999
     CACHE 5;  -- MODIFIED: different cache size
 
+-- MODIFIED: start_value and MINVALUE raised from 1 to 10000000.
+-- The comparer must emit RESTART WITH 10000000 so PostgreSQL does not fall back to
+-- the old recorded start value (1) and raise:
+--   ERROR: RESTART value (1) cannot be less than MINVALUE (10000000)
+CREATE SEQUENCE test_schema.minvalue_raise_seq
+    START WITH 10000000  -- MODIFIED: raised from 1
+    INCREMENT BY 1
+    MINVALUE 10000000    -- MODIFIED: raised from 1
+    MAXVALUE 999999999
+    CACHE 1
+    CYCLE;               -- MODIFIED: NO CYCLE → CYCLE
+
 -- New sequence
 CREATE SEQUENCE new_reporting_schema.report_id_seq
     START WITH 1


### PR DESCRIPTION
Features:
  - Fixed splitting arguments issue.
  - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
  - `coninhcount` i16 -> i32.
  - Fixed altering sequences with values.