### PR TITLE
Apply v1.0.13

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,27 @@
 
                 Features:
                     - Changed `coninhcount` i16 -> i32 to support PG14+.
+                    - Added PostgreSQL 14–18 support:
+                        - Virtual generated columns (`GENERATED ALWAYS AS (...) VIRTUAL`).
+                        - `NOT ENFORCED` / `ENFORCED` constraints with ALTER support.
+                        - Temporal primary key and unique constraints (`WITHOUT OVERLAPS`).
+                        - Exclusion constraints (`contype 'x'`) support.
+                        - Named NOT NULL constraints (PG18 `contype 'n'`).
+                        - `NULLS NOT DISTINCT` for unique constraints and indexes.
+                        - `NO INHERIT` constraint flag with ALTER support.
+                        - Table access method (`USING`) with `ALTER TABLE SET ACCESS METHOD`.
+                        - Column `STORAGE` and `COMPRESSION` settings with ALTER support.
+                        - `SECURITY INVOKER` views with ALTER SET/RESET support.
+                        - Unlogged sequences (`CREATE UNLOGGED SEQUENCE`) with ALTER support.
+                        - `MAINTAIN` privilege for table ACLs.
+                        - Range and multirange type support (`CREATE TYPE AS RANGE`), including
+                          `pg_range` metadata fetch (subtype, collation, opclass, canonical,
+                          subdiff, multirange name) with PG13/PG14 compatibility.
+                    - New object types:
+                        - Foreign tables: full support for `CREATE FOREIGN TABLE`, `ALTER`,
+                          `DROP`, column management, table/column options, and comparison.
+                        - Extended statistics: `CREATE STATISTICS`, `ALTER`, `DROP`, and
+                          comparison via `pg_statistic_ext`.
 
 2026-04-08      v1.0.12
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-                v1.0.13
+2026-04-09      v1.0.13
 
                 Features:
                     - Changed `coninhcount` i16 -> i32 to support PG14+.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
+                v1.0.13
+
+                Features:
+                    - Changed `coninhcount` i16 -> i32 to support PG14+.
+
 2026-04-08      v1.0.12
 
                 Features:
                     - Fixed splitting arguments issue.
                     - Flag `use_drop` / `--use-drop` currently affects all DROP statements; when disabled, DROP statements are commented out instead of executed.
-                    - `coninhcount` i16 -> i32.
                     - Fixed altering sequences with values.
 
 2026-04-07      v1.0.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ CMD ["pgc", "--help"]
 # Metadata
 LABEL maintainer="nettrash" \
       description="PostgreSQL Database Comparer (PGC) - A tool for comparing PostgreSQL database schemas" \
-      version="1.0.12" \
+      version="1.0.13" \
       org.opencontainers.image.title="pgc" \
       org.opencontainers.image.description="PostgreSQL Database Comparer" \
-      org.opencontainers.image.version="1.0.12" \
+      org.opencontainers.image.version="1.0.13" \
       org.opencontainers.image.source="https://github.com/nettrash/pgc" \
       org.opencontainers.image.licenses="MIT"

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -137,19 +137,39 @@ impl Comparer {
     /// Mark columns in `self.to.tables` that should be output as serial/bigserial/smallserial.
     /// Called after `compare_sequences()` which populates `self.serial_columns`.
     fn mark_serial_columns(&mut self) {
-        for (key, serial_type) in &self.serial_columns {
-            let parts: Vec<&str> = key.splitn(3, '.').collect();
-            if parts.len() == 3 {
-                let (schema, table, column) = (parts[0], parts[1], parts[2]);
-                if let Some(to_table) = self
-                    .to
-                    .tables
-                    .iter_mut()
-                    .find(|t| t.schema == schema && t.name == table)
-                    && let Some(to_column) = to_table.columns.iter_mut().find(|c| c.name == column)
-                {
-                    to_column.serial_type = Some(serial_type.clone());
+        // Build index map for O(1) table lookup
+        let to_table_idx: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
+        // Collect indices first to avoid borrow conflict
+        let updates: Vec<(usize, String, String)> = self
+            .serial_columns
+            .iter()
+            .filter_map(|(key, serial_type)| {
+                let parts: Vec<&str> = key.splitn(3, '.').collect();
+                if parts.len() == 3 {
+                    let (schema, table, column) = (parts[0], parts[1], parts[2]);
+                    to_table_idx
+                        .get(&(schema, table))
+                        .map(|&idx| (idx, column.to_string(), serial_type.clone()))
+                } else {
+                    None
                 }
+            })
+            .collect();
+
+        for (tidx, column, serial_type) in updates {
+            if let Some(to_column) = self.to.tables[tidx]
+                .columns
+                .iter_mut()
+                .find(|c| c.name == column)
+            {
+                to_column.serial_type = Some(serial_type);
             }
         }
     }
@@ -163,7 +183,7 @@ impl Comparer {
         }
     }
 
-    fn process_target_routine(&mut self, routine: &Routine) {
+    fn process_target_routine(&mut self, routine: &Routine, from_routine: Option<&Routine>) {
         if routine.hash.is_none() {
             self.script.push_str(
                 format!(
@@ -175,9 +195,7 @@ impl Comparer {
             return;
         }
 
-        if let Some(from_routine) = self.from.routines.iter().find(|r| {
-            r.name == routine.name && r.schema == routine.schema && r.arguments == routine.arguments
-        }) {
+        if let Some(from_routine) = from_routine {
             if from_routine.hash.is_none() {
                 self.script.push_str(
                     format!(
@@ -442,7 +460,23 @@ impl Comparer {
     }
 
     fn normalized_view_key(schema: &str, name: &str) -> String {
-        Self::normalized_view_reference(format!("{}.{}", schema, name).as_str())
+        let mut result = String::with_capacity(schema.len() + name.len() + 1);
+        for c in schema.chars() {
+            if !matches!(c, '"' | '\'' | '`') {
+                for lc in c.to_lowercase() {
+                    result.push(lc);
+                }
+            }
+        }
+        result.push('.');
+        for c in name.chars() {
+            if !matches!(c, '"' | '\'' | '`') {
+                for lc in c.to_lowercase() {
+                    result.push(lc);
+                }
+            }
+        }
+        result
     }
 
     /// Check whether `text` contains an occurrence of the qualified name
@@ -657,6 +691,15 @@ impl Comparer {
     fn dependent_view_keys(&self) -> HashSet<String> {
         let mut dependent_views = HashSet::new();
 
+        // Build O(1) lookup for target tables
+        let to_table_map: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
         // Collect normalised keys for every table that will be altered or dropped,
         // so we can cheaply look them up when scanning materialized view relations.
         let altered_or_dropped: HashSet<String> = self
@@ -664,11 +707,8 @@ impl Comparer {
             .tables
             .iter()
             .filter(|table| {
-                let matching = self
-                    .to
-                    .tables
-                    .iter()
-                    .find(|t| t.schema == table.schema && t.name == table.name);
+                let matching_idx = to_table_map.get(&(table.schema.as_str(), table.name.as_str()));
+                let matching = matching_idx.map(|&idx| &self.to.tables[idx]);
                 let will_be_dropped = matching.is_none() && self.use_drop;
                 let will_be_altered = matching
                     .map(|target| Self::hashes_differ(&target.hash, &table.hash))
@@ -679,11 +719,8 @@ impl Comparer {
             .collect();
 
         for table in &self.from.tables {
-            let matching_table = self
-                .to
-                .tables
-                .iter()
-                .find(|t| t.schema == table.schema && t.name == table.name);
+            let matching_idx = to_table_map.get(&(table.schema.as_str(), table.name.as_str()));
+            let matching_table = matching_idx.map(|&idx| &self.to.tables[idx]);
 
             let will_be_dropped = matching_table.is_none() && self.use_drop;
             let will_be_altered = matching_table
@@ -734,10 +771,19 @@ impl Comparer {
         self.script
             .append_block("\n/* ---> Schemas: Start section --------------- */");
 
+        let from_schema_map: HashMap<&str, usize> = self
+            .from
+            .schemas
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.name.as_str(), i))
+            .collect();
+
         // We will find all new schemas from "to" dump that are not in "from" dump
         // and add them to the script.
         for schema in &self.to.schemas {
-            if let Some(from_schema) = self.from.schemas.iter().find(|s| s.name == schema.name) {
+            if let Some(&idx) = from_schema_map.get(schema.name.as_str()) {
+                let from_schema = &self.from.schemas[idx];
                 if Self::hashes_differ(&from_schema.hash, &schema.hash) {
                     self.script
                         .push_str(format!("\n/* Schema: {}*/\n", schema.name).as_str());
@@ -789,13 +835,24 @@ impl Comparer {
         // We will find all new extensions from "to" dump that are not in "from" dump
         // and add them to the script.
         // Also we will find only in "from" dump extensions that are not in "to" dump and drop them.
+        let from_ext_map: HashMap<(&str, &str), usize> = self
+            .from
+            .extensions
+            .iter()
+            .enumerate()
+            .map(|(i, e)| ((e.schema.as_str(), e.name.as_str()), i))
+            .collect();
+
+        let to_ext_keys: HashSet<(&str, &str)> = self
+            .to
+            .extensions
+            .iter()
+            .map(|e| (e.schema.as_str(), e.name.as_str()))
+            .collect();
+
         for ext in &self.to.extensions {
-            if let Some(from_ext) = self
-                .from
-                .extensions
-                .iter()
-                .find(|r| r.name == ext.name && r.schema == ext.schema)
-            {
+            if let Some(&idx) = from_ext_map.get(&(ext.schema.as_str(), ext.name.as_str())) {
+                let from_ext = &self.from.extensions[idx];
                 if from_ext.owner != ext.owner {
                     self.script.push_str(
                         format!("/* Extension: {}.{}*/\n", ext.schema, ext.name).as_str(),
@@ -816,13 +873,8 @@ impl Comparer {
         }
 
         for ext in &self.from.extensions {
-            if let Some(_to_ext) = self
-                .to
-                .extensions
-                .iter()
-                .find(|r| r.name == ext.name && r.schema == ext.schema)
-            {
-                continue; // Routine is present in both dumps, we already processed it
+            if to_ext_keys.contains(&(ext.schema.as_str(), ext.name.as_str())) {
+                continue; // Extension is present in both dumps, we already processed it
             } else {
                 // Extension is not present in 'to' dump and should be dropped.
                 self.script
@@ -856,16 +908,29 @@ impl Comparer {
         self.script
             .append_block("\n/* ---> User-defined types: Start --------------- */");
 
+        let from_type_map: HashMap<(&str, &str), usize> = self
+            .from
+            .types
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.typname.as_str()), i))
+            .collect();
+
+        let to_type_keys: HashSet<(&str, &str)> = self
+            .to
+            .types
+            .iter()
+            .map(|t| (t.schema.as_str(), t.typname.as_str()))
+            .collect();
+
         for to_type in &self.to.types {
             if (to_type.typtype as u8 as char) == 'e' {
                 continue;
             }
-            if let Some(from_type) = self
-                .from
-                .types
-                .iter()
-                .find(|t| t.schema == to_type.schema && t.typname == to_type.typname)
+            if let Some(&idx) =
+                from_type_map.get(&(to_type.schema.as_str(), to_type.typname.as_str()))
             {
+                let from_type = &self.from.types[idx];
                 if Self::hashes_differ(&from_type.hash, &to_type.hash) {
                     self.script.push_str(
                         format!("/* Type: {}.{} */\n", to_type.schema, to_type.typname).as_str(),
@@ -893,12 +958,7 @@ impl Comparer {
                 if (from_type.typtype as u8 as char) == 'e' {
                     continue;
                 }
-                if self
-                    .to
-                    .types
-                    .iter()
-                    .any(|t| t.schema == from_type.schema && t.typname == from_type.typname)
-                {
+                if to_type_keys.contains(&(from_type.schema.as_str(), from_type.typname.as_str())) {
                     continue;
                 }
 
@@ -946,6 +1006,22 @@ impl Comparer {
 
         let mut drop_section = String::new();
 
+        // Build lookup maps for O(1) access (reuses type maps since enums are stored in types)
+        let from_type_map: HashMap<(&str, &str), usize> = self
+            .from
+            .types
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.typname.as_str()), i))
+            .collect();
+
+        let to_type_keys: HashSet<(&str, &str)> = self
+            .to
+            .types
+            .iter()
+            .map(|t| (t.schema.as_str(), t.typname.as_str()))
+            .collect();
+
         let to_enums = self
             .to
             .types
@@ -963,12 +1039,10 @@ impl Comparer {
                 );
                 continue;
             }
-            if let Some(from_enum) = self
-                .from
-                .types
-                .iter()
-                .find(|t| t.schema == to_enum.schema && t.typname == to_enum.typname)
+            if let Some(&idx) =
+                from_type_map.get(&(to_enum.schema.as_str(), to_enum.typname.as_str()))
             {
+                let from_enum = &self.from.types[idx];
                 if from_enum.hash.is_none() {
                     self.script.push_str(
                         format!(
@@ -1007,12 +1081,7 @@ impl Comparer {
                 .iter()
                 .filter(|t| (t.typtype as u8 as char) == 'e')
             {
-                if self
-                    .to
-                    .types
-                    .iter()
-                    .any(|t| t.schema == from_enum.schema && t.typname == from_enum.typname)
-                {
+                if to_type_keys.contains(&(from_enum.schema.as_str(), from_enum.typname.as_str())) {
                     continue;
                 }
 
@@ -1063,6 +1132,38 @@ impl Comparer {
 
         let mut drop_section = String::new();
 
+        // Build lookup maps for O(1) access
+        let from_seq_map: HashMap<(&str, &str), usize> = self
+            .from
+            .sequences
+            .iter()
+            .enumerate()
+            .map(|(i, s)| ((s.schema.as_str(), s.name.as_str()), i))
+            .collect();
+
+        let to_seq_keys: HashSet<(&str, &str)> = self
+            .to
+            .sequences
+            .iter()
+            .map(|s| (s.schema.as_str(), s.name.as_str()))
+            .collect();
+
+        let to_table_map: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
+        let from_table_map: HashMap<(&str, &str), usize> = self
+            .from
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
         // We will find all new sequences from "to" dump that are not in "from" dump
         // and we will find all existing sequences in both dumps with different hashes
         // and add them to the script.
@@ -1077,12 +1178,10 @@ impl Comparer {
                 );
                 continue;
             }
-            if let Some(from_sequence) = self
-                .from
-                .sequences
-                .iter()
-                .find(|s| s.name == sequence.name && s.schema == sequence.schema)
+            if let Some(&idx) =
+                from_seq_map.get(&(sequence.schema.as_str(), sequence.name.as_str()))
             {
+                let from_sequence = &self.from.sequences[idx];
                 if from_sequence.hash.is_none() {
                     self.script.push_str(
                         format!(
@@ -1107,38 +1206,37 @@ impl Comparer {
                     &sequence.owned_by_schema,
                     &sequence.owned_by_table,
                     &sequence.owned_by_column,
-                ) && let Some(to_table) = self
-                    .to
-                    .tables
-                    .iter()
-                    .find(|t| t.schema == *schema && t.name == *table)
-                    && let Some(to_column) = to_table.columns.iter().find(|c| c.name == *column)
+                ) && let Some(&tidx) = to_table_map.get(&(schema.as_str(), table.as_str()))
                 {
-                    let is_identity = to_column.is_identity;
-                    let is_serial = to_column
-                        .column_default
-                        .as_ref()
-                        .is_some_and(|d| d.to_lowercase().contains("nextval("));
+                    let to_table = &self.to.tables[tidx];
+                    if let Some(to_column) = to_table.columns.iter().find(|c| c.name == *column) {
+                        let is_identity = to_column.is_identity;
+                        let is_serial = to_column
+                            .column_default
+                            .as_ref()
+                            .is_some_and(|d| d.to_lowercase().contains("nextval("));
 
-                    if is_identity || is_serial {
-                        if is_serial {
-                            let serial_type = match to_column.data_type.to_lowercase().as_str() {
-                                "integer" => "serial",
-                                "bigint" => "bigserial",
-                                "smallint" => "smallserial",
-                                _ => "serial",
-                            };
-                            let key = format!("{}.{}.{}", schema, table, column);
-                            self.serial_columns.insert(key, serial_type.to_string());
+                        if is_identity || is_serial {
+                            if is_serial {
+                                let serial_type = match to_column.data_type.to_lowercase().as_str()
+                                {
+                                    "integer" => "serial",
+                                    "bigint" => "bigserial",
+                                    "smallint" => "smallserial",
+                                    _ => "serial",
+                                };
+                                let key = format!("{}.{}.{}", schema, table, column);
+                                self.serial_columns.insert(key, serial_type.to_string());
+                            }
+                            self.script.push_str(
+                                        format!(
+                                            "/* Skipping sequence {}.{} as it will be created by column {}.{}.{} (identity/serial) */\n",
+                                            sequence.schema, sequence.name, schema, table, column
+                                        )
+                                        .as_str(),
+                                    );
+                            continue;
                         }
-                        self.script.push_str(
-                                    format!(
-                                        "/* Skipping sequence {}.{} as it will be created by column {}.{}.{} (identity/serial) */\n",
-                                        sequence.schema, sequence.name, schema, table, column
-                                    )
-                                    .as_str(),
-                                );
-                        continue;
                     }
                 }
 
@@ -1156,12 +1254,7 @@ impl Comparer {
                     continue;
                 }
 
-                if let Some(_to_sequence) = self
-                    .to
-                    .sequences
-                    .iter()
-                    .find(|s| s.name == sequence.name && s.schema == sequence.schema)
-                {
+                if to_seq_keys.contains(&(sequence.schema.as_str(), sequence.name.as_str())) {
                     continue; // Sequence is present in both dumps, we already processed it
                 }
 
@@ -1169,13 +1262,9 @@ impl Comparer {
                 if let (Some(schema), Some(table)) =
                     (&sequence.owned_by_schema, &sequence.owned_by_table)
                 {
-                    let to_table = self
-                        .to
-                        .tables
-                        .iter()
-                        .find(|t| t.schema == *schema && t.name == *table);
+                    let to_table_idx = to_table_map.get(&(schema.as_str(), table.as_str()));
 
-                    if to_table.is_none() {
+                    if to_table_idx.is_none() {
                         self.script.push_str(
                             format!(
                                 "/* Skipping drop of sequence {}.{} as it is owned by table {}.{} which will be dropped. */\n",
@@ -1188,7 +1277,7 @@ impl Comparer {
 
                     // Table exists in TO. Check if column exists or if it was an identity column.
                     if let Some(column_name) = &sequence.owned_by_column {
-                        let to_table = to_table.unwrap();
+                        let to_table = &self.to.tables[*to_table_idx.unwrap()];
                         let to_column = to_table.columns.iter().find(|c| c.name == *column_name);
 
                         if to_column.is_none() {
@@ -1203,23 +1292,22 @@ impl Comparer {
                         }
 
                         // Column exists in TO. Check if it was an identity column in FROM.
-                        if let Some(from_table) = self
-                            .from
-                            .tables
-                            .iter()
-                            .find(|t| t.schema == *schema && t.name == *table)
-                            && let Some(from_column) =
-                                from_table.columns.iter().find(|c| c.name == *column_name)
-                            && from_column.is_identity
+                        if let Some(&fidx) = from_table_map.get(&(schema.as_str(), table.as_str()))
                         {
-                            self.script.push_str(
-                                        format!(
-                                            "/* Skipping drop of sequence {}.{} as it is owned by identity column {}.{}.{}. */\n",
-                                            sequence.schema, sequence.name, schema, table, column_name
-                                        )
-                                        .as_str(),
-                                    );
-                            continue;
+                            let from_table = &self.from.tables[fidx];
+                            if let Some(from_column) =
+                                from_table.columns.iter().find(|c| c.name == *column_name)
+                                && from_column.is_identity
+                            {
+                                self.script.push_str(
+                                            format!(
+                                                "/* Skipping drop of sequence {}.{} as it is owned by identity column {}.{}.{}. */\n",
+                                                sequence.schema, sequence.name, schema, table, column_name
+                                            )
+                                            .as_str(),
+                                        );
+                                continue;
+                            }
                         }
                     }
                 }
@@ -1269,15 +1357,29 @@ impl Comparer {
         self.script
             .append_block("\n/* ---> Routines: Start section --------------- */");
 
+        // Build O(1) lookup maps (owned keys to avoid borrowing self)
+        let to_routine_keys: HashSet<(String, String, String)> = self
+            .to
+            .routines
+            .iter()
+            .map(|r| (r.schema.clone(), r.name.clone(), r.arguments.clone()))
+            .collect();
+
+        let from_routine_map: HashMap<(String, String, String), usize> = self
+            .from
+            .routines
+            .iter()
+            .enumerate()
+            .map(|(i, r)| ((r.schema.clone(), r.name.clone(), r.arguments.clone()), i))
+            .collect();
+
         // ── Drop routines not present in TO (reverse dependency order) ──
         let routines_to_drop: Vec<Routine> = self
             .from
             .routines
             .iter()
             .filter(|r| {
-                !self.to.routines.iter().any(|tr| {
-                    tr.name == r.name && tr.schema == r.schema && tr.arguments == r.arguments
-                })
+                !to_routine_keys.contains(&(r.schema.clone(), r.name.clone(), r.arguments.clone()))
             })
             .cloned()
             .collect();
@@ -1395,7 +1497,14 @@ impl Comparer {
 
             for idx in sorted {
                 let routine = &create_routines[idx].1;
-                self.process_target_routine(routine);
+                let from_routine = from_routine_map
+                    .get(&(
+                        routine.schema.clone(),
+                        routine.name.clone(),
+                        routine.arguments.clone(),
+                    ))
+                    .map(|&i| self.from.routines[i].clone());
+                self.process_target_routine(routine, from_routine.as_ref());
             }
         }
 
@@ -1414,16 +1523,28 @@ impl Comparer {
         // We will drop all tables that exists just in "from" dump (partitions first).
         let ordered_from_drop = Self::ordered_tables_for_drop(&self.from.tables);
 
+        // Build lookup maps for O(1) access
+        let to_table_map: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
+        let from_table_map: HashMap<(&str, &str), usize> = self
+            .from
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
         // Pass 1: collect FK drops for all tables that will be removed.
         let mut fk_pre_drop = String::new();
         let mut dropped_fk_keys: HashSet<String> = HashSet::new();
         for table in ordered_from_drop.iter() {
-            if self
-                .to
-                .tables
-                .iter()
-                .any(|t| t.name == table.name && t.schema == table.schema)
-            {
+            if to_table_map.contains_key(&(table.schema.as_str(), table.name.as_str())) {
                 continue;
             }
 
@@ -1504,12 +1625,7 @@ impl Comparer {
 
         // Pass 2: drop tables (and their triggers) now that FK dependencies are removed.
         for table in ordered_from_drop.iter() {
-            if let Some(_to_table) = self
-                .to
-                .tables
-                .iter()
-                .find(|t| t.name == table.name && t.schema == table.schema)
-            {
+            if to_table_map.contains_key(&(table.schema.as_str(), table.name.as_str())) {
                 continue; // Table is present in both dumps, we already processed it
             }
 
@@ -1560,14 +1676,11 @@ impl Comparer {
         // contains a DROP TABLE.
         let mut recreated_parents: HashSet<String> = HashSet::new();
         for table in ordered_from.iter() {
-            if let Some(to_table) = self
-                .to
-                .tables
-                .iter()
-                .find(|t| t.name == table.name && t.schema == table.schema)
-                && table.partition_key != to_table.partition_key
-            {
-                recreated_parents.insert(Self::table_key(&table.schema, &table.name));
+            if let Some(&tidx) = to_table_map.get(&(table.schema.as_str(), table.name.as_str())) {
+                let to_table = &self.to.tables[tidx];
+                if table.partition_key != to_table.partition_key {
+                    recreated_parents.insert(Self::table_key(&table.schema, &table.name));
+                }
             }
         }
 
@@ -1590,12 +1703,8 @@ impl Comparer {
                 );
                 continue;
             }
-            if let Some(from_table) = self
-                .from
-                .tables
-                .iter()
-                .find(|t| t.name == table.name && t.schema == table.schema)
-            {
+            if let Some(&fidx) = from_table_map.get(&(table.schema.as_str(), table.name.as_str())) {
+                let from_table = &self.from.tables[fidx];
                 if from_table.hash.is_none() {
                     self.script.push_str(
                         format!(
@@ -1647,12 +1756,8 @@ impl Comparer {
                 );
                 continue;
             }
-            if let Some(to_table) = self
-                .to
-                .tables
-                .iter()
-                .find(|t| t.name == table.name && t.schema == table.schema)
-            {
+            if let Some(&tidx) = to_table_map.get(&(table.schema.as_str(), table.name.as_str())) {
+                let to_table = &self.to.tables[tidx];
                 if to_table.hash.is_none() {
                     self.script.push_str(
                         format!(
@@ -1726,17 +1831,21 @@ impl Comparer {
         self.script
             .append_block("\n/* ---> Foreign Keys: Start section --------------- */");
 
+        let from_table_map: HashMap<(&str, &str), usize> = self
+            .from
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
         for table in &self.to.tables {
             if table.hash.is_none() {
                 continue;
             }
 
-            if let Some(from_table) = self
-                .from
-                .tables
-                .iter()
-                .find(|t| t.name == table.name && t.schema == table.schema)
-            {
+            if let Some(&fidx) = from_table_map.get(&(table.schema.as_str(), table.name.as_str())) {
+                let from_table = &self.from.tables[fidx];
                 if from_table.hash.is_none() {
                     continue;
                 }
@@ -1763,24 +1872,26 @@ impl Comparer {
         let dependent_views = self.dependent_view_keys();
         self.dropped_views.clear();
 
+        // Build O(1) lookup for target views
+        let to_view_map: HashMap<(&str, &str), usize> = self
+            .to
+            .views
+            .iter()
+            .enumerate()
+            .map(|(i, v)| ((v.schema.as_str(), v.name.as_str()), i))
+            .collect();
+
         // Collect all views that should be dropped: (from_view index, normalized_key, force_drop)
         let mut candidates: Vec<(usize, String, bool)> = Vec::new();
 
         for (idx, from_view) in self.from.views.iter().enumerate() {
             let normalized_view = Self::normalized_view_key(&from_view.schema, &from_view.name);
 
-            // Determine why this view should be dropped (if at all):
-            // 1. It is temporarily needed before a table alteration/drop (dependent).
-            // 2. It no longer exists in the target dump (FROM-only permanent drop).
-            // 3. It is a materialized view whose definition has changed — mat views
-            //    cannot use CREATE OR REPLACE, so they must be dropped and recreated.
             let is_dependent = dependent_views.contains(&normalized_view);
 
-            let to_view = self
-                .to
-                .views
-                .iter()
-                .find(|v| v.schema == from_view.schema && v.name == from_view.name);
+            let to_view = to_view_map
+                .get(&(from_view.schema.as_str(), from_view.name.as_str()))
+                .map(|&i| &self.to.views[i]);
 
             let is_from_only = to_view.is_none();
 
@@ -2171,6 +2282,30 @@ impl Comparer {
         self.script
             .append_block("\n/* ---> Routines & Views: Start section --------------- */");
 
+        // Build O(1) lookup maps (owned keys to avoid borrowing self)
+        let to_routine_keys: HashSet<(String, String, String)> = self
+            .to
+            .routines
+            .iter()
+            .map(|r| (r.schema.clone(), r.name.clone(), r.arguments.clone()))
+            .collect();
+
+        let from_routine_map: HashMap<(String, String, String), usize> = self
+            .from
+            .routines
+            .iter()
+            .enumerate()
+            .map(|(i, r)| ((r.schema.clone(), r.name.clone(), r.arguments.clone()), i))
+            .collect();
+
+        let from_view_map: HashMap<(String, String), usize> = self
+            .from
+            .views
+            .iter()
+            .enumerate()
+            .map(|(i, v)| ((v.schema.clone(), v.name.clone()), i))
+            .collect();
+
         // ──────────────────────────────────────────────────────────
         // Phase 1 – Drop routines that are not present in TO
         // ──────────────────────────────────────────────────────────
@@ -2179,9 +2314,7 @@ impl Comparer {
             .routines
             .iter()
             .filter(|r| {
-                !self.to.routines.iter().any(|tr| {
-                    tr.name == r.name && tr.schema == r.schema && tr.arguments == r.arguments
-                })
+                !to_routine_keys.contains(&(r.schema.clone(), r.name.clone(), r.arguments.clone()))
             })
             .cloned()
             .collect();
@@ -2258,11 +2391,13 @@ impl Comparer {
             if routine.hash.is_none() {
                 continue;
             }
-            let from_routine = self.from.routines.iter().find(|r| {
-                r.name == routine.name
-                    && r.schema == routine.schema
-                    && r.arguments == routine.arguments
-            });
+            let from_routine = from_routine_map
+                .get(&(
+                    routine.schema.clone(),
+                    routine.name.clone(),
+                    routine.arguments.clone(),
+                ))
+                .map(|&i| &self.from.routines[i]);
             let needs_action = match from_routine {
                 None => true,
                 Some(fr) => fr.hash.is_some() && Self::hashes_differ(&fr.hash, &routine.hash),
@@ -2274,11 +2409,9 @@ impl Comparer {
 
         for (idx, view) in self.to.views.iter().enumerate() {
             let normalized_view = Self::normalized_view_key(&view.schema, &view.name);
-            let from_view = self
-                .from
-                .views
-                .iter()
-                .find(|v| v.schema == view.schema && v.name == view.name);
+            let from_view = from_view_map
+                .get(&(view.schema.clone(), view.name.clone()))
+                .map(|&i| &self.from.views[i]);
             let was_dropped = self.dropped_views.contains_key(&normalized_view);
             let definition_changed = from_view
                 .map(|fv| Self::hashes_differ(&fv.hash, &view.hash))
@@ -2425,7 +2558,14 @@ impl Comparer {
                 self.emit_view_create(&view);
             } else {
                 let routine = self.to.routines[orig_idx].clone();
-                self.process_target_routine(&routine);
+                let from_routine = from_routine_map
+                    .get(&(
+                        routine.schema.clone(),
+                        routine.name.clone(),
+                        routine.arguments.clone(),
+                    ))
+                    .map(|&i| self.from.routines[i].clone());
+                self.process_target_routine(&routine, from_routine.as_ref());
             }
         }
 
@@ -2434,16 +2574,15 @@ impl Comparer {
         // ──────────────────────────────────────────────────────────
         for &idx in &no_action_view_indices {
             let to_view = &self.to.views[idx];
-            if let Some(fv) = self
-                .from
-                .views
-                .iter()
-                .find(|v| v.schema == to_view.schema && v.name == to_view.name)
-                && fv.owner != to_view.owner
+            if let Some(&fidx) = from_view_map.get(&(to_view.schema.clone(), to_view.name.clone()))
             {
-                self.script
-                    .push_str(format!("/* View: {}.{}*/\n", to_view.schema, to_view.name).as_str());
-                self.script.push_str(&to_view.get_owner_script());
+                let fv = &self.from.views[fidx];
+                if fv.owner != to_view.owner {
+                    self.script.push_str(
+                        format!("/* View: {}.{}*/\n", to_view.schema, to_view.name).as_str(),
+                    );
+                    self.script.push_str(&to_view.get_owner_script());
+                }
             }
         }
 

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2641,6 +2641,47 @@ impl Comparer {
             }
         }
 
+        // --- Foreign Tables ---
+        let from_ft_map: HashMap<(&str, &str), (&[String], &str)> = self
+            .from
+            .foreign_tables
+            .iter()
+            .map(|ft| {
+                (
+                    (ft.schema.as_str(), ft.name.as_str()),
+                    (ft.acl.as_slice(), ft.owner.as_str()),
+                )
+            })
+            .collect();
+
+        for ft in &self.to.foreign_tables {
+            let (from_acl, from_owner) = from_ft_map
+                .get(&(ft.schema.as_str(), ft.name.as_str()))
+                .copied()
+                .unwrap_or((&[], ""));
+            let owners: Vec<&str> = [from_owner, ft.owner.as_str()]
+                .into_iter()
+                .filter(|o| !o.is_empty())
+                .collect();
+            let object_name = format!("{}.{}", ft.schema, ft.name);
+            let grants_script = acl::generate_grants_script(
+                from_acl,
+                &ft.acl,
+                full,
+                "FOREIGN TABLE",
+                &object_name,
+                &owners,
+            );
+            if !grants_script.is_empty() {
+                if self.use_comments {
+                    self.script.push_str(
+                        format!("/* Grants for foreign table: {} */\n", object_name).as_str(),
+                    );
+                }
+                self.script.push_str(&grants_script);
+            }
+        }
+
         // --- Routines ---
         for routine in &self.to.routines {
             let (from_acl, from_owner) = from_routine_map

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -105,6 +105,8 @@ impl Comparer {
         self.drop_views().await?;
         self.compare_tables().await?;
         self.compare_foreign_keys().await?;
+        self.compare_foreign_tables().await?;
+        self.compare_statistics().await?;
         if !self.sequence_post_script.is_empty() {
             self.script.push_str(&self.sequence_post_script);
             self.sequence_post_script.clear();
@@ -2046,6 +2048,116 @@ impl Comparer {
         }
     }
 
+    /// Compare foreign tables between dumps.
+    async fn compare_foreign_tables(&mut self) -> Result<(), Error> {
+        self.script
+            .append_block("/* ---> Compare Foreign Tables --------------- */");
+
+        let from_map: std::collections::HashMap<String, &crate::dump::foreign_table::ForeignTable> =
+            self.from
+                .foreign_tables
+                .iter()
+                .map(|ft| (format!("{}.{}", ft.schema, ft.name), ft))
+                .collect();
+
+        let to_map: std::collections::HashMap<String, &crate::dump::foreign_table::ForeignTable> =
+            self.to
+                .foreign_tables
+                .iter()
+                .map(|ft| (format!("{}.{}", ft.schema, ft.name), ft))
+                .collect();
+
+        // Drop foreign tables that exist only in FROM
+        for (key, ft) in &from_map {
+            if !to_map.contains_key(key) {
+                if self.use_drop {
+                    self.script.push_str(&ft.get_drop_script());
+                } else {
+                    let drop_script = ft.get_drop_script();
+                    self.script.push_str(
+                        &drop_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                    );
+                }
+            }
+        }
+
+        // Create or alter foreign tables in TO
+        for ft in &self.to.foreign_tables {
+            let key = format!("{}.{}", ft.schema, ft.name);
+            if let Some(existing) = from_map.get(&key) {
+                // Alter if hash differs
+                if existing.hash != ft.hash {
+                    let alter = existing.get_alter_script(ft);
+                    if !alter.is_empty() {
+                        self.script.push_str(&alter);
+                    }
+                }
+            } else {
+                // Create new foreign table
+                self.script.push_str(&ft.get_script());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Compare extended statistics between dumps.
+    async fn compare_statistics(&mut self) -> Result<(), Error> {
+        self.script
+            .append_block("/* ---> Compare Statistics --------------- */");
+
+        let from_map: std::collections::HashMap<String, &crate::dump::statistic::Statistic> = self
+            .from
+            .statistics
+            .iter()
+            .map(|s| (format!("{}.{}", s.schema, s.name), s))
+            .collect();
+
+        let to_map: std::collections::HashMap<String, &crate::dump::statistic::Statistic> = self
+            .to
+            .statistics
+            .iter()
+            .map(|s| (format!("{}.{}", s.schema, s.name), s))
+            .collect();
+
+        // Drop statistics that exist only in FROM
+        for (key, stat) in &from_map {
+            if !to_map.contains_key(key) {
+                if self.use_drop {
+                    self.script.push_str(&stat.get_drop_script());
+                } else {
+                    let drop_script = stat.get_drop_script();
+                    self.script.push_str(
+                        &drop_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                    );
+                }
+            }
+        }
+
+        // Create or alter statistics in TO
+        for stat in &self.to.statistics {
+            let key = format!("{}.{}", stat.schema, stat.name);
+            if let Some(existing) = from_map.get(&key) {
+                if existing.hash != stat.hash {
+                    let alter = existing.get_alter_script(stat);
+                    if !alter.is_empty() {
+                        self.script.push_str(&alter);
+                    }
+                }
+            } else {
+                self.script.push_str(&stat.get_script());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Compare routines and views together, respecting cross-dependencies.
     ///
     /// Instead of processing all routines before all views (which breaks when
@@ -3344,9 +3456,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         }
     }
@@ -3420,9 +3535,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
 
@@ -3521,9 +3639,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
 
@@ -3883,9 +4004,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
 
@@ -3980,9 +4104,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
 
@@ -4048,9 +4175,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
 
@@ -4140,6 +4270,9 @@ mod tests {
                     "FOREIGN KEY (parent_id) REFERENCES public.parent(id)".to_string(),
                 ),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             }],
             vec![],
             vec![],
@@ -4705,9 +4838,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
         let serial_table = Table::new(
@@ -4790,9 +4926,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         };
         let bigserial_table = Table::new(
@@ -7137,6 +7276,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("FOREIGN KEY (user_id) REFERENCES public.users(id)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             }],
             vec![],
             vec![],
@@ -7216,6 +7358,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("FOREIGN KEY (user_id) REFERENCES public.users(id)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             }],
             vec![],
             vec![],

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2090,7 +2090,7 @@ impl Comparer {
             if let Some(existing) = from_map.get(&key) {
                 // Alter if hash differs
                 if existing.hash != ft.hash {
-                    let alter = existing.get_alter_script(ft);
+                    let alter = existing.get_alter_script(ft, self.use_drop);
                     if !alter.is_empty() {
                         self.script.push_str(&alter);
                     }
@@ -2145,7 +2145,7 @@ impl Comparer {
             let key = format!("{}.{}", stat.schema, stat.name);
             if let Some(existing) = from_map.get(&key) {
                 if existing.hash != stat.hash {
-                    let alter = existing.get_alter_script(stat);
+                    let alter = existing.get_alter_script(stat, self.use_drop);
                     if !alter.is_empty() {
                         self.script.push_str(&alter);
                     }

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2164,19 +2164,25 @@ impl Comparer {
         self.script
             .append_block("/* ---> Compare Foreign Tables --------------- */");
 
-        let from_map: std::collections::HashMap<String, &crate::dump::foreign_table::ForeignTable> =
-            self.from
-                .foreign_tables
-                .iter()
-                .map(|ft| (format!("{}.{}", ft.schema, ft.name), ft))
-                .collect();
+        let from_map: std::collections::HashMap<
+            (&str, &str),
+            &crate::dump::foreign_table::ForeignTable,
+        > = self
+            .from
+            .foreign_tables
+            .iter()
+            .map(|ft| ((ft.schema.as_str(), ft.name.as_str()), ft))
+            .collect();
 
-        let to_map: std::collections::HashMap<String, &crate::dump::foreign_table::ForeignTable> =
-            self.to
-                .foreign_tables
-                .iter()
-                .map(|ft| (format!("{}.{}", ft.schema, ft.name), ft))
-                .collect();
+        let to_map: std::collections::HashMap<
+            (&str, &str),
+            &crate::dump::foreign_table::ForeignTable,
+        > = self
+            .to
+            .foreign_tables
+            .iter()
+            .map(|ft| ((ft.schema.as_str(), ft.name.as_str()), ft))
+            .collect();
 
         // Drop foreign tables that exist only in FROM
         for (key, ft) in &from_map {
@@ -2197,7 +2203,7 @@ impl Comparer {
 
         // Create or alter foreign tables in TO
         for ft in &self.to.foreign_tables {
-            let key = format!("{}.{}", ft.schema, ft.name);
+            let key = (ft.schema.as_str(), ft.name.as_str());
             if let Some(existing) = from_map.get(&key) {
                 // Alter if hash differs
                 if existing.hash != ft.hash {
@@ -2220,19 +2226,19 @@ impl Comparer {
         self.script
             .append_block("/* ---> Compare Statistics --------------- */");
 
-        let from_map: std::collections::HashMap<String, &crate::dump::statistic::Statistic> = self
-            .from
-            .statistics
-            .iter()
-            .map(|s| (format!("{}.{}", s.schema, s.name), s))
-            .collect();
+        let from_map: std::collections::HashMap<(&str, &str), &crate::dump::statistic::Statistic> =
+            self.from
+                .statistics
+                .iter()
+                .map(|s| ((s.schema.as_str(), s.name.as_str()), s))
+                .collect();
 
-        let to_map: std::collections::HashMap<String, &crate::dump::statistic::Statistic> = self
-            .to
-            .statistics
-            .iter()
-            .map(|s| (format!("{}.{}", s.schema, s.name), s))
-            .collect();
+        let to_map: std::collections::HashMap<(&str, &str), &crate::dump::statistic::Statistic> =
+            self.to
+                .statistics
+                .iter()
+                .map(|s| ((s.schema.as_str(), s.name.as_str()), s))
+                .collect();
 
         // Drop statistics that exist only in FROM
         for (key, stat) in &from_map {
@@ -2253,7 +2259,7 @@ impl Comparer {
 
         // Create or alter statistics in TO
         for stat in &self.to.statistics {
-            let key = format!("{}.{}", stat.schema, stat.name);
+            let key = (stat.schema.as_str(), stat.name.as_str());
             if let Some(existing) = from_map.get(&key) {
                 if existing.hash != stat.hash {
                     let alter = existing.get_alter_script(stat, self.use_drop);

--- a/app/src/dump/acl.rs
+++ b/app/src/dump/acl.rs
@@ -58,6 +58,7 @@ impl AclEntry {
             'C' => Some("CREATE"),
             'c' => Some("CONNECT"),
             'T' => Some("TEMPORARY"),
+            'm' => Some("MAINTAIN"),
             _ => None,
         }
     }
@@ -73,6 +74,7 @@ impl AclEntry {
                 "TRUNCATE",
                 "REFERENCES",
                 "TRIGGER",
+                "MAINTAIN",
             ],
             "SEQUENCE" => &["USAGE", "SELECT", "UPDATE"],
             "FUNCTION" | "PROCEDURE" => &["EXECUTE"],

--- a/app/src/dump/core.rs
+++ b/app/src/dump/core.rs
@@ -1744,8 +1744,17 @@ impl Dump {
                 }
             }
 
-            // Now drop the tables
+            // Now drop the tables — partitions before their parents
+            let mut partition_children: Vec<&Table> = Vec::new();
+            let mut regular_tables: Vec<&Table> = Vec::new();
             for table in &self.tables {
+                if table.partition_of.is_some() {
+                    partition_children.push(table);
+                } else {
+                    regular_tables.push(table);
+                }
+            }
+            for table in partition_children.iter().chain(regular_tables.iter()) {
                 if use_comments {
                     script.push_str(&format!(
                         "/* Drop table: {}.{} */\n",
@@ -1762,7 +1771,7 @@ impl Dump {
             }
         }
 
-        // 3. Drop routines (functions, procedures, aggregates)
+        // 3. Drop foreign tables
         if !self.foreign_tables.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Foreign Tables --------------- */");
@@ -1840,7 +1849,7 @@ impl Dump {
             }
         }
 
-        // 4. Drop sequences
+        // 6. Drop sequences
         if !self.sequences.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Sequences --------------- */");
@@ -1862,7 +1871,7 @@ impl Dump {
             }
         }
 
-        // 5. Drop types (includes enums, composites, domains, etc.)
+        // 7. Drop types (includes enums, composites, domains, range types, etc.)
         if !self.types.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Types --------------- */");
@@ -1884,7 +1893,7 @@ impl Dump {
             }
         }
 
-        // 6. Drop extensions
+        // 8. Drop extensions
         if !self.extensions.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Extensions --------------- */");
@@ -1900,7 +1909,7 @@ impl Dump {
             }
         }
 
-        // 7. Drop schemas (last, since everything else lives inside them)
+        // 9. Drop schemas (last, since everything else lives inside them)
         if !self.schemas.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Schemas --------------- */");

--- a/app/src/dump/core.rs
+++ b/app/src/dump/core.rs
@@ -1,8 +1,10 @@
+use crate::dump::foreign_table::{ForeignTable, ForeignTableColumn};
 use crate::dump::pg_enum::PgEnum;
 use crate::dump::pg_type::{CompositeAttribute, DomainConstraint, PgType};
 use crate::dump::routine::Routine;
 use crate::dump::schema::Schema;
 use crate::dump::sequence::Sequence;
+use crate::dump::statistic::Statistic;
 use crate::dump::table::Table;
 use crate::dump::view::View;
 use crate::{config::dump_config::DumpConfig, dump::extension::Extension};
@@ -27,7 +29,7 @@ use zip::write::SimpleFileOptions;
 ///
 /// **Keep in sync** with the number of non-table futures passed to
 /// `tokio::try_join!` in `Dump::fill()`.
-const FILL_SIBLING_BRANCH_COUNT: u32 = 5;
+const FILL_SIBLING_BRANCH_COUNT: u32 = 7;
 
 // This file defines the Dump struct and its serialization/deserialization logic.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +61,14 @@ pub struct Dump {
 
     // List of views in the dump.
     pub views: Vec<View>,
+
+    // List of foreign tables in the dump.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub foreign_tables: Vec<ForeignTable>,
+
+    // List of extended statistics in the dump.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub statistics: Vec<Statistic>,
 }
 
 impl Dump {
@@ -74,6 +84,8 @@ impl Dump {
             routines: Vec::new(),
             tables: Vec::new(),
             views: Vec::new(),
+            foreign_tables: Vec::new(),
+            statistics: Vec::new(),
         }
     }
 
@@ -160,14 +172,27 @@ impl Dump {
         let routines_fut = Self::fetch_routines_standalone(pool, &schema_filter);
         let tables_fut = Self::fetch_tables_standalone(pool, &schema_filter, max_connections);
         let views_fut = Self::fetch_views_standalone(pool, &schema_filter);
+        let foreign_tables_fut = Self::fetch_foreign_tables_standalone(pool, &schema_filter);
+        let statistics_fut = Self::fetch_statistics_standalone(pool, &schema_filter);
 
-        let (types_enums, extensions, sequences, routines, tables, views) = tokio::try_join!(
+        let (
+            types_enums,
+            extensions,
+            sequences,
+            routines,
+            tables,
+            views,
+            foreign_tables,
+            statistics,
+        ) = tokio::try_join!(
             types_enums_fut,
             extensions_fut,
             sequences_fut,
             routines_fut,
             tables_fut,
             views_fut,
+            foreign_tables_fut,
+            statistics_fut,
         )?;
 
         let (types, enums) = types_enums;
@@ -178,6 +203,8 @@ impl Dump {
         self.routines = routines;
         self.tables = tables;
         self.views = views;
+        self.foreign_tables = foreign_tables;
+        self.statistics = statistics;
 
         Ok(())
     }
@@ -335,6 +362,85 @@ impl Dump {
                 .push(attribute);
         }
 
+        // Fetch range type metadata from pg_range
+        let range_pg_version: i32 =
+            sqlx::query_scalar("select current_setting('server_version_num')::int4;")
+                .fetch_one(pool)
+                .await
+                .map_err(|e| {
+                    Error::other(format!(
+                        "Failed to fetch server_version_num for types: {e}."
+                    ))
+                })?;
+
+        let multirange_col = if range_pg_version >= 140000 {
+            "quote_ident(mt.typname) as multirange_name"
+        } else {
+            "null::text as multirange_name"
+        };
+        let multirange_join = if range_pg_version >= 140000 {
+            "left join pg_type mt on mt.oid = r.rngmultitypid"
+        } else {
+            ""
+        };
+
+        let range_metadata_rows = sqlx::query(
+            format!(
+                "select
+                    r.rngtypid as type_oid,
+                    pg_catalog.format_type(r.rngsubtype, null) as range_subtype,
+                    case when r.rngcollation <> 0 then
+                        (select quote_ident(n.nspname) || '.' || quote_ident(c.collname)
+                         from pg_collation c join pg_namespace n on n.oid = c.collnamespace
+                         where c.oid = r.rngcollation)
+                    else null end as range_collation,
+                    quote_ident(opc.opcname) as range_opclass,
+                    case when r.rngcanonical <> 0 then r.rngcanonical::regproc::text else null end as range_canonical,
+                    case when r.rngsubdiff <> 0 then r.rngsubdiff::regproc::text else null end as range_subdiff,
+                    {}
+                from pg_range r
+                join pg_type t on t.oid = r.rngtypid
+                join pg_namespace n on n.oid = t.typnamespace
+                join pg_opclass opc on opc.oid = r.rngsubopc
+                {}
+                where n.nspname in {}
+                  and not exists (
+                      select 1 from pg_depend ext_dep
+                      where ext_dep.objid = t.oid
+                      and ext_dep.deptype = 'e'
+                  )",
+                multirange_col, multirange_join, schema_filter
+            )
+            .as_str(),
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| Error::other(format!("Failed to fetch range type metadata: {e}.")))?;
+
+        struct RangeMetadata {
+            subtype: String,
+            collation: Option<String>,
+            opclass: String,
+            canonical: Option<String>,
+            subdiff: Option<String>,
+            multirange_name: Option<String>,
+        }
+        let mut range_metadata_map: HashMap<Oid, RangeMetadata> = HashMap::new();
+        for row in range_metadata_rows {
+            let type_oid: Oid = row.get("type_oid");
+            range_metadata_map.insert(
+                type_oid,
+                RangeMetadata {
+                    subtype: row.get("range_subtype"),
+                    collation: row.get::<Option<String>, _>("range_collation"),
+                    opclass: row.get("range_opclass"),
+                    canonical: row.get::<Option<String>, _>("range_canonical"),
+                    subdiff: row.get::<Option<String>, _>("range_subdiff"),
+                    multirange_name: row.get::<Option<String>, _>("multirange_name"),
+                },
+            );
+        }
+
         let rows = sqlx::query(
             format!(
                 "select 
@@ -447,8 +553,23 @@ impl Dump {
                     composite_attributes: composite_attributes_map
                         .remove(&row.get::<Oid, _>("type_oid"))
                         .unwrap_or_default(),
+                    range_subtype: None,
+                    range_collation: None,
+                    range_opclass: None,
+                    range_canonical: None,
+                    range_subdiff: None,
+                    multirange_name: None,
                     hash: None,
                 };
+                // Populate range metadata if available
+                if let Some(rm) = range_metadata_map.remove(&pgtype.oid) {
+                    pgtype.range_subtype = Some(rm.subtype);
+                    pgtype.range_collation = rm.collation;
+                    pgtype.range_opclass = Some(rm.opclass);
+                    pgtype.range_canonical = rm.canonical;
+                    pgtype.range_subdiff = rm.subdiff;
+                    pgtype.multirange_name = rm.multirange_name;
+                }
                 pgtype.hash();
                 println!(
                     " - {} (namespace: {}, hash: {})",
@@ -592,7 +713,8 @@ impl Dump {
                 quote_ident(owner_attr.attname) as owned_by_column,
                 dep.deptype::text as dependency_type,
                 seq_desc.description as seq_comment,
-                seq_class.relacl::text[] as seq_acl
+                seq_class.relacl::text[] as seq_acl,
+                seq_class.relpersistence::text as seq_persistence
             from
                 pg_sequences seq
                 left join pg_namespace seq_ns on seq_ns.nspname = seq.schemaname
@@ -642,6 +764,8 @@ impl Dump {
                     owned_by_table: row.get::<Option<String>, _>("owned_by_table"),
                     owned_by_column: row.get::<Option<String>, _>("owned_by_column"),
                     is_identity: false,
+                    is_unlogged: row.get::<Option<String>, _>("seq_persistence").as_deref()
+                        == Some("u"),
                     comment: row.get("seq_comment"),
                     hash: None,
                     acl: row
@@ -868,6 +992,13 @@ impl Dump {
                 .unwrap_or(None)
                 .is_some();
 
+        // Detect PostgreSQL server version for conditional feature support.
+        let pg_version: i32 =
+            sqlx::query_scalar("select current_setting('server_version_num')::int4;")
+                .fetch_one(pool)
+                .await
+                .unwrap_or(0);
+
         let query = format!(
             "
                 select
@@ -882,11 +1013,13 @@ impl Dump {
                     t.hasrules,
                     t.rowsecurity,
                     d.description as table_comment,
-                    c.relacl::text[] as table_acl
+                    c.relacl::text[] as table_acl,
+                    am.amname as access_method
                 from pg_tables t
                 left join pg_class c on c.relname = t.tablename
                     and c.relkind in ('r','p')
                     and c.relnamespace = (select oid from pg_namespace where nspname = t.schemaname)
+                left join pg_am am on am.oid = c.relam
                 left join pg_description d on d.objoid = c.oid and d.objsubid = 0
                 where 
                     t.schemaname not in ('pg_catalog', 'information_schema') 
@@ -936,6 +1069,9 @@ impl Dump {
                 partition_of: None,
                 partition_bound: None,
                 comment: row.get("table_comment"),
+                access_method: row
+                    .get::<Option<String>, _>("access_method")
+                    .filter(|am| am != "heap"),
                 hash: None,
                 acl: row
                     .get::<Option<Vec<String>>, _>("table_acl")
@@ -949,9 +1085,12 @@ impl Dump {
         let pool_ref = pool;
         let tables: Vec<Result<Table, Error>> = stream::iter(shell_tables)
             .map(|mut table| async move {
-                table.fill(pool_ref, has_tabledef_fn).await.map_err(|e| {
-                    Error::other(format!("Failed to fill table {}: {}.", table.name, e))
-                })?;
+                table
+                    .fill(pool_ref, has_tabledef_fn, pg_version)
+                    .await
+                    .map_err(|e| {
+                        Error::other(format!("Failed to fill table {}: {}.", table.name, e))
+                    })?;
                 table.hash();
                 println!(
                     " - {}.{} (hash: {})",
@@ -991,7 +1130,8 @@ impl Dump {
                     quote_ident(pv.viewowner) as view_owner,
                     array_agg(distinct vtu.table_schema || '.' || vtu.table_name) as table_relation,
                     d.description as view_comment,
-                    (select cc.relacl::text[] from pg_class cc where cc.oid = c.oid) as view_acl
+                    (select cc.relacl::text[] from pg_class cc where cc.oid = c.oid) as view_acl,
+                    coalesce(c.reloptions::text[] @> array['security_invoker=true']::text[], false) as security_invoker
             from information_schema.views v
             join information_schema.view_table_usage vtu on v.table_name = vtu.view_name and v.table_schema = vtu.view_schema
             left join pg_views pv on pv.schemaname = v.table_schema and pv.viewname = v.table_name
@@ -1005,7 +1145,7 @@ impl Dump {
                     where ext_dep.objid = c.oid
                     and ext_dep.deptype = 'e'
                 )
-            group by v.table_schema, v.table_name, v.view_definition, pv.viewowner, d.description, c.oid;",
+            group by v.table_schema, v.table_name, v.view_definition, pv.viewowner, d.description, c.oid, c.reloptions;",
             schema_filter
         );
 
@@ -1076,6 +1216,7 @@ impl Dump {
                     acl: row
                         .get::<Option<Vec<String>>, _>("view_acl")
                         .unwrap_or_default(),
+                    security_invoker: row.get("security_invoker"),
                 };
                 view.hash();
                 println!(
@@ -1107,6 +1248,7 @@ impl Dump {
                     acl: row
                         .get::<Option<Vec<String>>, _>("view_acl")
                         .unwrap_or_default(),
+                    security_invoker: false,
                 };
                 view.hash();
                 println!(
@@ -1120,6 +1262,262 @@ impl Dump {
         }
 
         Ok(views)
+    }
+
+    async fn fetch_foreign_tables_standalone(
+        pool: &PgPool,
+        schema_filter: &str,
+    ) -> Result<Vec<ForeignTable>, Error> {
+        let rows = sqlx::query(
+            format!(
+                "select
+                    quote_ident(n.nspname) as ft_schema,
+                    quote_ident(c.relname) as ft_name,
+                    quote_ident(s.srvname) as ft_server,
+                    quote_ident(r.rolname) as ft_owner,
+                    ft.ftoptions as ft_options,
+                    d.description as ft_comment,
+                    c.relacl::text[] as ft_acl
+                from pg_foreign_table ft
+                join pg_class c on c.oid = ft.ftrelid
+                join pg_namespace n on n.oid = c.relnamespace
+                join pg_foreign_server s on s.oid = ft.ftserver
+                left join pg_roles r on r.oid = c.relowner
+                left join pg_description d on d.objoid = c.oid
+                    and d.classoid = 'pg_class'::regclass
+                    and d.objsubid = 0
+                where
+                    n.nspname in {}
+                    and not exists (
+                        select 1 from pg_depend ext_dep
+                        where ext_dep.objid = c.oid
+                        and ext_dep.deptype = 'e'
+                    )
+                order by n.nspname, c.relname",
+                schema_filter
+            )
+            .as_str(),
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| Error::other(format!("Failed to fetch foreign tables: {e}.")))?;
+
+        let mut foreign_tables = Vec::new();
+
+        if rows.is_empty() {
+            println!("No foreign tables found.");
+        } else {
+            println!("Foreign tables found:");
+
+            // Fetch all foreign table columns at once
+            let col_rows = sqlx::query(
+                format!(
+                    "select
+                        quote_ident(n.nspname) as ft_schema,
+                        quote_ident(c.relname) as ft_name,
+                        quote_ident(a.attname) as col_name,
+                        pg_catalog.format_type(a.atttypid, a.atttypmod) as col_type,
+                        a.attnotnull as col_notnull,
+                        pg_get_expr(ad.adbin, ad.adrelid) as col_default,
+                        coalesce(
+                            array(
+                                select option_name || ' ' || quote_literal(option_value)
+                                from pg_options_to_table(a.attfdwoptions)
+                            ),
+                            array[]::text[]
+                        ) as col_options
+                    from pg_attribute a
+                    join pg_class c on c.oid = a.attrelid
+                    join pg_namespace n on n.oid = c.relnamespace
+                    join pg_foreign_table ft on ft.ftrelid = c.oid
+                    left join pg_attrdef ad on ad.adrelid = a.attrelid and ad.adnum = a.attnum
+                    where
+                        n.nspname in {}
+                        and a.attnum > 0
+                        and not a.attisdropped
+                        and not exists (
+                            select 1 from pg_depend ext_dep
+                            where ext_dep.objid = c.oid
+                            and ext_dep.deptype = 'e'
+                        )
+                    order by n.nspname, c.relname, a.attnum",
+                    schema_filter
+                )
+                .as_str(),
+            )
+            .fetch_all(pool)
+            .await
+            .map_err(|e| Error::other(format!("Failed to fetch foreign table columns: {e}.")))?;
+
+            // Build column map: (schema, name) -> Vec<ForeignTableColumn>
+            let mut col_map: HashMap<(String, String), Vec<ForeignTableColumn>> = HashMap::new();
+            for row in col_rows {
+                let key = (
+                    row.get::<String, _>("ft_schema"),
+                    row.get::<String, _>("ft_name"),
+                );
+                let col = ForeignTableColumn {
+                    name: row.get("col_name"),
+                    data_type: row.get("col_type"),
+                    is_nullable: !row.get::<bool, _>("col_notnull"),
+                    column_default: row.get::<Option<String>, _>("col_default"),
+                    options: row
+                        .get::<Option<Vec<String>>, _>("col_options")
+                        .unwrap_or_default(),
+                };
+                col_map.entry(key).or_default().push(col);
+            }
+
+            for row in rows {
+                let schema: String = row.get("ft_schema");
+                let name: String = row.get("ft_name");
+                let columns = col_map
+                    .remove(&(schema.clone(), name.clone()))
+                    .unwrap_or_default();
+
+                let options = row
+                    .get::<Option<Vec<String>>, _>("ft_options")
+                    .unwrap_or_default();
+
+                let mut ft = ForeignTable {
+                    schema: schema.clone(),
+                    name: name.clone(),
+                    server: row.get("ft_server"),
+                    owner: row.get::<Option<String>, _>("ft_owner").unwrap_or_default(),
+                    options,
+                    columns,
+                    comment: row.get::<Option<String>, _>("ft_comment"),
+                    hash: None,
+                    acl: row
+                        .get::<Option<Vec<String>>, _>("ft_acl")
+                        .unwrap_or_default(),
+                };
+                ft.hash();
+                println!(
+                    " - {}.{} (server: {}, hash: {})",
+                    ft.schema,
+                    ft.name,
+                    ft.server,
+                    ft.hash.as_deref().unwrap_or("None")
+                );
+                foreign_tables.push(ft);
+            }
+        }
+
+        Ok(foreign_tables)
+    }
+
+    async fn fetch_statistics_standalone(
+        pool: &PgPool,
+        schema_filter: &str,
+    ) -> Result<Vec<Statistic>, Error> {
+        let rows = sqlx::query(
+            format!(
+                "select
+                    quote_ident(n.nspname) as stat_schema,
+                    quote_ident(s.stxname) as stat_name,
+                    quote_ident(r.rolname) as stat_owner,
+                    quote_ident(tn.nspname) as table_schema,
+                    quote_ident(tc.relname) as table_name,
+                    s.stxkind::text[] as stat_kinds,
+                    pg_get_statisticsobjdef(s.oid) as stat_def,
+                    d.description as stat_comment
+                from pg_statistic_ext s
+                join pg_namespace n on n.oid = s.stxnamespace
+                join pg_class tc on tc.oid = s.stxrelid
+                join pg_namespace tn on tn.oid = tc.relnamespace
+                left join pg_roles r on r.oid = s.stxowner
+                left join pg_description d on d.objoid = s.oid
+                    and d.classoid = 'pg_statistic_ext'::regclass
+                    and d.objsubid = 0
+                where
+                    n.nspname in {}
+                    and not exists (
+                        select 1 from pg_depend ext_dep
+                        where ext_dep.objid = s.oid
+                        and ext_dep.deptype = 'e'
+                    )
+                order by n.nspname, s.stxname",
+                schema_filter
+            )
+            .as_str(),
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| Error::other(format!("Failed to fetch extended statistics: {e}.")))?;
+
+        let mut statistics = Vec::new();
+
+        if rows.is_empty() {
+            println!("No extended statistics found.");
+        } else {
+            println!("Extended statistics found:");
+
+            for row in rows {
+                let stat_def: String = row.get("stat_def");
+                let kind_chars: Vec<String> = row
+                    .get::<Option<Vec<String>>, _>("stat_kinds")
+                    .unwrap_or_default();
+
+                let kinds: Vec<String> = kind_chars
+                    .iter()
+                    .map(|k| match k.as_str() {
+                        "d" => "dependencies".to_string(),
+                        "f" => "ndistinct".to_string(),
+                        "m" => "mcv".to_string(),
+                        "e" => "expressions".to_string(),
+                        other => other.to_string(),
+                    })
+                    .collect();
+
+                // Extract column names from the definition
+                // Definition format: "CREATE STATISTICS ... ON col1, col2 FROM table"
+                let columns = Self::parse_statistics_columns(&stat_def);
+
+                let mut stat = Statistic {
+                    schema: row.get("stat_schema"),
+                    name: row.get("stat_name"),
+                    owner: row
+                        .get::<Option<String>, _>("stat_owner")
+                        .unwrap_or_default(),
+                    table_schema: row.get("table_schema"),
+                    table_name: row.get("table_name"),
+                    kinds,
+                    columns,
+                    definition: stat_def,
+                    comment: row.get::<Option<String>, _>("stat_comment"),
+                    hash: None,
+                };
+                stat.hash();
+                println!(
+                    " - {}.{} (hash: {})",
+                    stat.schema,
+                    stat.name,
+                    stat.hash.as_deref().unwrap_or("None")
+                );
+                statistics.push(stat);
+            }
+        }
+
+        Ok(statistics)
+    }
+
+    fn parse_statistics_columns(def: &str) -> Vec<String> {
+        // Parse columns from pg_get_statisticsobjdef output
+        // Format: "... ON col1, col2 FROM ..."
+        let upper = def.to_uppercase();
+        if let Some(on_pos) = upper.find(" ON ") {
+            let after_on = &def[on_pos + 4..];
+            if let Some(from_pos) = after_on.to_uppercase().find(" FROM ") {
+                let cols_str = &after_on[..from_pos];
+                return cols_str
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+        }
+        Vec::new()
     }
 
     // Read a dump from a file and deserialize it.
@@ -1351,6 +1749,50 @@ impl Dump {
         }
 
         // 3. Drop routines (functions, procedures, aggregates)
+        if !self.foreign_tables.is_empty() {
+            if use_comments {
+                script.append_block("\n/* ---> Drop Foreign Tables --------------- */");
+            }
+            for ft in &self.foreign_tables {
+                if use_comments {
+                    script.push_str(&format!(
+                        "/* Drop foreign table: {}.{} */\n",
+                        ft.schema, ft.name
+                    ));
+                }
+                script.push_str(
+                    &format!(
+                        "drop foreign table if exists {}.{}{cascade_suffix};",
+                        ft.schema, ft.name
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        // 4. Drop extended statistics
+        if !self.statistics.is_empty() {
+            if use_comments {
+                script.append_block("\n/* ---> Drop Statistics --------------- */");
+            }
+            for stat in &self.statistics {
+                if use_comments {
+                    script.push_str(&format!(
+                        "/* Drop statistics: {}.{} */\n",
+                        stat.schema, stat.name
+                    ));
+                }
+                script.push_str(
+                    &format!(
+                        "drop statistics if exists {}.{}{cascade_suffix};",
+                        stat.schema, stat.name
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        // 5. Drop routines (functions, procedures, aggregates)
         if !self.routines.is_empty() {
             if use_comments {
                 script.append_block("\n/* ---> Drop Routines --------------- */");
@@ -1528,6 +1970,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         Table::new(
             schema.to_string(),
@@ -1641,6 +2086,12 @@ mod tests {
             enum_labels: Vec::new(),
             domain_constraints: Vec::new(),
             composite_attributes: Vec::new(),
+            range_subtype: None,
+            range_collation: None,
+            range_opclass: None,
+            range_canonical: None,
+            range_subdiff: None,
+            multirange_name: None,
             comment: None,
             hash: None,
         }

--- a/app/src/dump/core.rs
+++ b/app/src/dump/core.rs
@@ -5,7 +5,7 @@ use crate::dump::routine::Routine;
 use crate::dump::schema::Schema;
 use crate::dump::sequence::Sequence;
 use crate::dump::statistic::Statistic;
-use crate::dump::table::Table;
+use crate::dump::table::{PgCatalogCaps, Table};
 use crate::dump::view::View;
 use crate::{config::dump_config::DumpConfig, dump::extension::Extension};
 use futures::stream::{self, StreamExt};
@@ -402,7 +402,7 @@ impl Dump {
                          from pg_collation c join pg_namespace n on n.oid = c.collnamespace
                          where c.oid = r.rngcollation)
                     else null end as range_collation,
-                    quote_ident(opc.opcname) as range_opclass,
+                    quote_ident(opc_ns.nspname) || '.' || quote_ident(opc.opcname) as range_opclass,
                     case when r.rngcanonical <> 0 then r.rngcanonical::regproc::text else null end as range_canonical,
                     case when r.rngsubdiff <> 0 then r.rngsubdiff::regproc::text else null end as range_subdiff,
                     {}
@@ -410,6 +410,7 @@ impl Dump {
                 join pg_type t on t.oid = r.rngtypid
                 join pg_namespace n on n.oid = t.typnamespace
                 join pg_opclass opc on opc.oid = r.rngsubopc
+                join pg_namespace opc_ns on opc_ns.oid = opc.opcnamespace
                 {}
                 where n.nspname in {}
                   and not exists (
@@ -1013,6 +1014,9 @@ impl Dump {
                 .await
                 .unwrap_or(0);
 
+        // Probe catalog capabilities once for the entire dump run.
+        let caps = PgCatalogCaps::detect(pool, pg_version).await;
+
         let query = format!(
             "
                 select
@@ -1100,7 +1104,7 @@ impl Dump {
         let tables: Vec<Result<Table, Error>> = stream::iter(shell_tables)
             .map(|mut table| async move {
                 table
-                    .fill(pool_ref, has_tabledef_fn, pg_version)
+                    .fill(pool_ref, has_tabledef_fn, pg_version, caps)
                     .await
                     .map_err(|e| {
                         Error::other(format!("Failed to fill table {}: {}.", table.name, e))

--- a/app/src/dump/core.rs
+++ b/app/src/dump/core.rs
@@ -687,11 +687,17 @@ impl Dump {
                     .push((enum_value.enumsortorder, enum_value.enumlabel.clone()));
             }
 
+            // Build OID-indexed map for O(1) lookup
+            let mut type_oid_map: HashMap<u32, usize> = HashMap::new();
+            for (i, t) in types.iter().enumerate() {
+                type_oid_map.insert(t.oid.0, i);
+            }
+
             for (type_oid, mut labels) in labels_by_type {
                 labels.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
 
-                if let Some(pg_type) = types.iter_mut().find(|t| t.oid.0 == type_oid) {
-                    pg_type.enum_labels = labels.into_iter().map(|(_, label)| label).collect();
+                if let Some(&idx) = type_oid_map.get(&type_oid) {
+                    types[idx].enum_labels = labels.into_iter().map(|(_, label)| label).collect();
                 }
             }
         }
@@ -1394,8 +1400,8 @@ impl Dump {
                     .unwrap_or_default();
 
                 let mut ft = ForeignTable {
-                    schema: schema.clone(),
-                    name: name.clone(),
+                    schema,
+                    name,
                     server: row.get("ft_server"),
                     owner: row.get::<Option<String>, _>("ft_owner").unwrap_or_default(),
                     options,

--- a/app/src/dump/core.rs
+++ b/app/src/dump/core.rs
@@ -373,12 +373,20 @@ impl Dump {
                     ))
                 })?;
 
-        let multirange_col = if range_pg_version >= 140000 {
+        let has_rngmultitypid: bool = range_pg_version >= 140000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_range'::regclass AND attname = 'rngmultitypid' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+
+        let multirange_col = if has_rngmultitypid {
             "quote_ident(mt.typname) as multirange_name"
         } else {
             "null::text as multirange_name"
         };
-        let multirange_join = if range_pg_version >= 140000 {
+        let multirange_join = if has_rngmultitypid {
             "left join pg_type mt on mt.oid = r.rngmultitypid"
         } else {
             ""
@@ -1275,7 +1283,13 @@ impl Dump {
                     quote_ident(c.relname) as ft_name,
                     quote_ident(s.srvname) as ft_server,
                     quote_ident(r.rolname) as ft_owner,
-                    ft.ftoptions as ft_options,
+                    coalesce(
+                        array(
+                            select option_name || ' ' || quote_literal(option_value)
+                            from pg_options_to_table(ft.ftoptions)
+                        ),
+                        array[]::text[]
+                    ) as ft_options,
                     d.description as ft_comment,
                     c.relacl::text[] as ft_acl
                 from pg_foreign_table ft
@@ -1462,8 +1476,8 @@ impl Dump {
                 let kinds: Vec<String> = kind_chars
                     .iter()
                     .map(|k| match k.as_str() {
-                        "d" => "dependencies".to_string(),
-                        "f" => "ndistinct".to_string(),
+                        "d" => "ndistinct".to_string(),
+                        "f" => "dependencies".to_string(),
                         "m" => "mcv".to_string(),
                         "e" => "expressions".to_string(),
                         other => other.to_string(),

--- a/app/src/dump/foreign_table.rs
+++ b/app/src/dump/foreign_table.rs
@@ -155,7 +155,7 @@ impl ForeignTable {
     }
 
     /// Returns an ALTER script to transform self into target.
-    pub fn get_alter_script(&self, target: &ForeignTable) -> String {
+    pub fn get_alter_script(&self, target: &ForeignTable, use_drop: bool) -> String {
         let mut statements = Vec::new();
 
         // Owner change
@@ -173,7 +173,22 @@ impl ForeignTable {
         if self.server != target.server {
             let drop = self.get_drop_script();
             let create = target.get_script();
-            return format!("{}{}", drop, create);
+            if use_drop {
+                return format!("{}{}", drop, create);
+            } else {
+                let commented_drop = drop
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                let commented_create = create
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                return format!(
+                    "-- use_drop=false: foreign table {}.{} requires drop+recreate; statements commented out\n{}{}",
+                    self.schema, self.name, commented_drop, commented_create
+                );
+            }
         }
 
         // Table options change
@@ -458,7 +473,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.owner = "new_owner".to_string();
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("alter foreign table public.ft_test owner to new_owner;"));
     }
 
@@ -467,7 +482,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.server = "new_server".to_string();
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("drop foreign table if exists public.ft_test;"));
         assert!(script.contains("create foreign table public.ft_test"));
         assert!(script.contains("server new_server"));
@@ -478,7 +493,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.columns.push(make_column("email", "text"));
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("alter foreign table public.ft_test add column email text;"));
     }
 
@@ -487,7 +502,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.columns.retain(|c| c.name != "name");
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("alter foreign table public.ft_test drop column name;"));
     }
 
@@ -496,7 +511,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.columns[0].data_type = "bigint".to_string();
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("alter foreign table public.ft_test alter column id type bigint;"));
     }
 
@@ -505,7 +520,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.columns[0].is_nullable = false;
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(
             script.contains("alter foreign table public.ft_test alter column id set not null;")
         );
@@ -516,7 +531,7 @@ mod tests {
         let mut ft1 = make_foreign_table();
         ft1.columns[0].is_nullable = false;
         let ft2 = make_foreign_table();
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(
             script.contains("alter foreign table public.ft_test alter column id drop not null;")
         );
@@ -527,7 +542,7 @@ mod tests {
         let ft1 = make_foreign_table();
         let mut ft2 = make_foreign_table();
         ft2.comment = Some("new comment".to_string());
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.contains("comment on foreign table public.ft_test is 'new comment';"));
     }
 
@@ -535,7 +550,19 @@ mod tests {
     fn get_alter_script_no_changes() {
         let ft1 = make_foreign_table();
         let ft2 = make_foreign_table();
-        let script = ft1.get_alter_script(&ft2);
+        let script = ft1.get_alter_script(&ft2, true);
         assert!(script.is_empty());
+    }
+
+    #[test]
+    fn get_alter_script_server_change_use_drop_false_comments_out() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.server = "new_server".to_string();
+        let script = ft1.get_alter_script(&ft2, false);
+        assert!(script.contains("-- use_drop=false"));
+        assert!(script.contains("-- drop foreign table"));
+        assert!(script.contains("-- create foreign table"));
+        assert!(!script.contains("\ndrop foreign table"));
     }
 }

--- a/app/src/dump/foreign_table.rs
+++ b/app/src/dump/foreign_table.rs
@@ -1,0 +1,541 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::utils::string_extensions::StringExt;
+
+/// A column in a foreign table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForeignTableColumn {
+    pub name: String,
+    pub data_type: String,
+    pub is_nullable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column_default: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
+}
+
+/// Information about a PostgreSQL foreign table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForeignTable {
+    pub schema: String,
+    pub name: String,
+    pub server: String,
+    pub owner: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
+    pub columns: Vec<ForeignTableColumn>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    pub hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub acl: Vec<String>,
+}
+
+impl ForeignTable {
+    pub fn new(
+        schema: String,
+        name: String,
+        server: String,
+        owner: String,
+        options: Vec<String>,
+        columns: Vec<ForeignTableColumn>,
+    ) -> Self {
+        let mut ft = Self {
+            schema,
+            name,
+            server,
+            owner,
+            options,
+            columns,
+            comment: None,
+            hash: None,
+            acl: Vec::new(),
+        };
+        ft.hash();
+        ft
+    }
+
+    pub fn hash(&mut self) {
+        let mut hasher = Sha256::new();
+        hasher.update(self.schema.as_bytes());
+        hasher.update(self.name.as_bytes());
+        hasher.update(self.server.as_bytes());
+        hasher.update(self.owner.as_bytes());
+
+        hasher.update((self.options.len() as u32).to_be_bytes());
+        for opt in &self.options {
+            hasher.update(opt.as_bytes());
+        }
+
+        hasher.update((self.columns.len() as u32).to_be_bytes());
+        for col in &self.columns {
+            hasher.update(col.name.as_bytes());
+            hasher.update(col.data_type.as_bytes());
+            hasher.update([col.is_nullable as u8]);
+            if let Some(def) = &col.column_default {
+                hasher.update(def.as_bytes());
+            }
+            hasher.update((col.options.len() as u32).to_be_bytes());
+            for opt in &col.options {
+                hasher.update(opt.as_bytes());
+            }
+        }
+
+        if let Some(comment) = &self.comment {
+            hasher.update((comment.len() as u32).to_be_bytes());
+            hasher.update(comment.as_bytes());
+        }
+
+        self.hash = Some(format!("{:x}", hasher.finalize()));
+    }
+
+    /// Returns a CREATE FOREIGN TABLE script.
+    pub fn get_script(&self) -> String {
+        let mut script = format!("create foreign table {}.{} (\n", self.schema, self.name);
+
+        for (i, col) in self.columns.iter().enumerate() {
+            script.push_str(&format!("    {} {}", col.name, col.data_type));
+            if !col.is_nullable {
+                script.push_str(" not null");
+            }
+            if let Some(def) = &col.column_default {
+                script.push_str(&format!(" default {}", def));
+            }
+            if !col.options.is_empty() {
+                script.push_str(&format!(" options ({})", col.options.join(", ")));
+            }
+            if i < self.columns.len() - 1 {
+                script.push(',');
+            }
+            script.push('\n');
+        }
+
+        script.push_str(&format!(")\nserver {}", self.server));
+
+        if !self.options.is_empty() {
+            script.push_str(&format!("\noptions ({})", self.options.join(", ")));
+        }
+
+        script.push(';');
+        let mut result = script.with_empty_lines();
+
+        if !self.owner.is_empty() {
+            result.push_str(
+                &format!(
+                    "alter foreign table {}.{} owner to {};",
+                    self.schema, self.name, self.owner
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        if let Some(comment) = &self.comment {
+            result.push_str(
+                &format!(
+                    "comment on foreign table {}.{} is '{}';",
+                    self.schema,
+                    self.name,
+                    comment.replace('\'', "''")
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        result
+    }
+
+    /// Returns a DROP FOREIGN TABLE script.
+    pub fn get_drop_script(&self) -> String {
+        format!(
+            "drop foreign table if exists {}.{};",
+            self.schema, self.name
+        )
+        .with_empty_lines()
+    }
+
+    /// Returns an ALTER script to transform self into target.
+    pub fn get_alter_script(&self, target: &ForeignTable) -> String {
+        let mut statements = Vec::new();
+
+        // Owner change
+        if self.owner != target.owner && !target.owner.is_empty() {
+            statements.push(
+                format!(
+                    "alter foreign table {}.{} owner to {};",
+                    target.schema, target.name, target.owner
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        // Server change requires drop+recreate
+        if self.server != target.server {
+            let drop = self.get_drop_script();
+            let create = target.get_script();
+            return format!("{}{}", drop, create);
+        }
+
+        // Table options change
+        if self.options != target.options {
+            if target.options.is_empty() {
+                // Reset all options — need to drop each individually
+                for opt in &self.options {
+                    if let Some(key) = opt.split_whitespace().next() {
+                        statements.push(
+                            format!(
+                                "alter foreign table {}.{} options (drop {});",
+                                target.schema, target.name, key
+                            )
+                            .with_empty_lines(),
+                        );
+                    }
+                }
+            } else {
+                // Use SET for simplicity — drop all old, add all new
+                statements.push(
+                    format!(
+                        "alter foreign table {}.{} options ({});",
+                        target.schema,
+                        target.name,
+                        target.options.join(", ")
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        // Column changes: detect added, dropped, and altered columns
+        let self_cols: std::collections::HashMap<&str, &ForeignTableColumn> =
+            self.columns.iter().map(|c| (c.name.as_str(), c)).collect();
+        let target_cols: std::collections::HashMap<&str, &ForeignTableColumn> = target
+            .columns
+            .iter()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+
+        // Drop columns that no longer exist
+        for col in &self.columns {
+            if !target_cols.contains_key(col.name.as_str()) {
+                statements.push(
+                    format!(
+                        "alter foreign table {}.{} drop column {};",
+                        target.schema, target.name, col.name
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        // Add new columns
+        for col in &target.columns {
+            if !self_cols.contains_key(col.name.as_str()) {
+                let mut col_def = format!("{} {}", col.name, col.data_type);
+                if !col.is_nullable {
+                    col_def.push_str(" not null");
+                }
+                if let Some(def) = &col.column_default {
+                    col_def.push_str(&format!(" default {}", def));
+                }
+                statements.push(
+                    format!(
+                        "alter foreign table {}.{} add column {};",
+                        target.schema, target.name, col_def
+                    )
+                    .with_empty_lines(),
+                );
+                if !col.options.is_empty() {
+                    statements.push(
+                        format!(
+                            "alter foreign table {}.{} alter column {} options (add {});",
+                            target.schema,
+                            target.name,
+                            col.name,
+                            col.options.join(", ")
+                        )
+                        .with_empty_lines(),
+                    );
+                }
+            }
+        }
+
+        // Alter existing columns
+        for col in &target.columns {
+            if let Some(existing) = self_cols.get(col.name.as_str()) {
+                if col.data_type != existing.data_type {
+                    statements.push(
+                        format!(
+                            "alter foreign table {}.{} alter column {} type {};",
+                            target.schema, target.name, col.name, col.data_type
+                        )
+                        .with_empty_lines(),
+                    );
+                }
+                if col.is_nullable != existing.is_nullable {
+                    if col.is_nullable {
+                        statements.push(
+                            format!(
+                                "alter foreign table {}.{} alter column {} drop not null;",
+                                target.schema, target.name, col.name
+                            )
+                            .with_empty_lines(),
+                        );
+                    } else {
+                        statements.push(
+                            format!(
+                                "alter foreign table {}.{} alter column {} set not null;",
+                                target.schema, target.name, col.name
+                            )
+                            .with_empty_lines(),
+                        );
+                    }
+                }
+                if col.column_default != existing.column_default {
+                    if let Some(def) = &col.column_default {
+                        statements.push(
+                            format!(
+                                "alter foreign table {}.{} alter column {} set default {};",
+                                target.schema, target.name, col.name, def
+                            )
+                            .with_empty_lines(),
+                        );
+                    } else {
+                        statements.push(
+                            format!(
+                                "alter foreign table {}.{} alter column {} drop default;",
+                                target.schema, target.name, col.name
+                            )
+                            .with_empty_lines(),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Comment change
+        if self.comment != target.comment {
+            if let Some(comment) = &target.comment {
+                statements.push(
+                    format!(
+                        "comment on foreign table {}.{} is '{}';",
+                        target.schema,
+                        target.name,
+                        comment.replace('\'', "''")
+                    )
+                    .with_empty_lines(),
+                );
+            } else {
+                statements.push(
+                    format!(
+                        "comment on foreign table {}.{} is null;",
+                        target.schema, target.name
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        statements.join("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_column(name: &str, data_type: &str) -> ForeignTableColumn {
+        ForeignTableColumn {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            is_nullable: true,
+            column_default: None,
+            options: Vec::new(),
+        }
+    }
+
+    fn make_foreign_table() -> ForeignTable {
+        ForeignTable::new(
+            "public".to_string(),
+            "ft_test".to_string(),
+            "remote_server".to_string(),
+            "postgres".to_string(),
+            Vec::new(),
+            vec![make_column("id", "integer"), make_column("name", "text")],
+        )
+    }
+
+    #[test]
+    fn hash_populates_hash_field() {
+        let ft = make_foreign_table();
+        assert!(ft.hash.is_some());
+    }
+
+    #[test]
+    fn hash_is_consistent() {
+        let ft1 = make_foreign_table();
+        let ft2 = make_foreign_table();
+        assert_eq!(ft1.hash, ft2.hash);
+    }
+
+    #[test]
+    fn hash_differs_with_different_server() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.server = "other_server".to_string();
+        ft2.hash();
+        assert_ne!(ft1.hash, ft2.hash);
+    }
+
+    #[test]
+    fn get_script_creates_foreign_table() {
+        let ft = make_foreign_table();
+        let script = ft.get_script();
+        assert!(script.contains("create foreign table public.ft_test"));
+        assert!(script.contains("server remote_server"));
+        assert!(script.contains("id integer"));
+        assert!(script.contains("name text"));
+    }
+
+    #[test]
+    fn get_script_includes_not_null() {
+        let mut ft = make_foreign_table();
+        ft.columns[0].is_nullable = false;
+        let script = ft.get_script();
+        assert!(script.contains("id integer not null"));
+    }
+
+    #[test]
+    fn get_script_includes_column_options() {
+        let mut ft = make_foreign_table();
+        ft.columns[0].options = vec!["column_name 'remote_id'".to_string()];
+        let script = ft.get_script();
+        assert!(script.contains("options (column_name 'remote_id')"));
+    }
+
+    #[test]
+    fn get_script_includes_table_options() {
+        let ft = ForeignTable::new(
+            "public".to_string(),
+            "ft_test".to_string(),
+            "remote_server".to_string(),
+            "postgres".to_string(),
+            vec![
+                "schema_name 'remote_schema'".to_string(),
+                "table_name 'remote_table'".to_string(),
+            ],
+            vec![make_column("id", "integer")],
+        );
+        let script = ft.get_script();
+        assert!(
+            script.contains("options (schema_name 'remote_schema', table_name 'remote_table')")
+        );
+    }
+
+    #[test]
+    fn get_script_includes_owner() {
+        let ft = make_foreign_table();
+        let script = ft.get_script();
+        assert!(script.contains("alter foreign table public.ft_test owner to postgres;"));
+    }
+
+    #[test]
+    fn get_script_includes_comment() {
+        let mut ft = make_foreign_table();
+        ft.comment = Some("test comment".to_string());
+        let script = ft.get_script();
+        assert!(script.contains("comment on foreign table public.ft_test is 'test comment';"));
+    }
+
+    #[test]
+    fn get_drop_script() {
+        let ft = make_foreign_table();
+        let script = ft.get_drop_script();
+        assert!(script.contains("drop foreign table if exists public.ft_test;"));
+    }
+
+    #[test]
+    fn get_alter_script_owner_change() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.owner = "new_owner".to_string();
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("alter foreign table public.ft_test owner to new_owner;"));
+    }
+
+    #[test]
+    fn get_alter_script_server_change_drops_recreates() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.server = "new_server".to_string();
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("drop foreign table if exists public.ft_test;"));
+        assert!(script.contains("create foreign table public.ft_test"));
+        assert!(script.contains("server new_server"));
+    }
+
+    #[test]
+    fn get_alter_script_add_column() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.columns.push(make_column("email", "text"));
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("alter foreign table public.ft_test add column email text;"));
+    }
+
+    #[test]
+    fn get_alter_script_drop_column() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.columns.retain(|c| c.name != "name");
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("alter foreign table public.ft_test drop column name;"));
+    }
+
+    #[test]
+    fn get_alter_script_change_column_type() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.columns[0].data_type = "bigint".to_string();
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("alter foreign table public.ft_test alter column id type bigint;"));
+    }
+
+    #[test]
+    fn get_alter_script_set_not_null() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.columns[0].is_nullable = false;
+        let script = ft1.get_alter_script(&ft2);
+        assert!(
+            script.contains("alter foreign table public.ft_test alter column id set not null;")
+        );
+    }
+
+    #[test]
+    fn get_alter_script_drop_not_null() {
+        let mut ft1 = make_foreign_table();
+        ft1.columns[0].is_nullable = false;
+        let ft2 = make_foreign_table();
+        let script = ft1.get_alter_script(&ft2);
+        assert!(
+            script.contains("alter foreign table public.ft_test alter column id drop not null;")
+        );
+    }
+
+    #[test]
+    fn get_alter_script_comment_change() {
+        let ft1 = make_foreign_table();
+        let mut ft2 = make_foreign_table();
+        ft2.comment = Some("new comment".to_string());
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.contains("comment on foreign table public.ft_test is 'new comment';"));
+    }
+
+    #[test]
+    fn get_alter_script_no_changes() {
+        let ft1 = make_foreign_table();
+        let ft2 = make_foreign_table();
+        let script = ft1.get_alter_script(&ft2);
+        assert!(script.is_empty());
+    }
+}

--- a/app/src/dump/mod.rs
+++ b/app/src/dump/mod.rs
@@ -1,11 +1,13 @@
 pub mod acl;
 pub mod core;
 pub mod extension;
+pub mod foreign_table;
 pub mod pg_enum;
 pub mod pg_type;
 pub mod routine;
 pub mod schema;
 pub mod sequence;
+pub mod statistic;
 pub mod table;
 pub mod table_column;
 pub mod table_constraint;

--- a/app/src/dump/pg_type.rs
+++ b/app/src/dump/pg_type.rs
@@ -70,6 +70,18 @@ pub struct PgType {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub composite_attributes: Vec<CompositeAttribute>, // Composite type attributes ordered by attnum
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_subtype: Option<String>, // Subtype for range types
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_collation: Option<String>, // Collation for range types
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_opclass: Option<String>, // Operator class for range types
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_canonical: Option<String>, // Canonical function for range types
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_subdiff: Option<String>, // Subtype diff function for range types
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multirange_name: Option<String>, // Multirange type name (for range types)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>, // Optional comment on the type
     pub hash: Option<String>, // SHA256 hash of the type definition
 }
@@ -152,6 +164,12 @@ impl PgType {
             enum_labels,
             domain_constraints,
             composite_attributes: Vec::new(),
+            range_subtype: None,
+            range_collation: None,
+            range_opclass: None,
+            range_canonical: None,
+            range_subdiff: None,
+            multirange_name: None,
             comment,
             hash: None,
         };
@@ -252,6 +270,26 @@ impl PgType {
             hasher.update((attribute.data_type.len() as u32).to_be_bytes());
             hasher.update(attribute.data_type.as_bytes());
         }
+
+        // Range type fields
+        update_option(&mut hasher, &self.range_subtype, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
+        update_option(&mut hasher, &self.range_collation, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
+        update_option(&mut hasher, &self.range_opclass, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
+        update_option(&mut hasher, &self.range_canonical, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
+        update_option(&mut hasher, &self.range_subdiff, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
+        update_option(&mut hasher, &self.multirange_name, |hasher, value| {
+            hasher.update(value.as_bytes());
+        });
 
         if let Some(comment) = &self.comment {
             hasher.update((comment.len() as u32).to_be_bytes());
@@ -387,14 +425,61 @@ impl PgType {
 
                 script
             }
-            'r' => format!(
-                "-- Range type {}.{} is not supported yet\n",
-                self.schema, self.typname
-            ),
-            'm' => format!(
-                "-- Multirange type {}.{} is not supported yet\n",
-                self.schema, self.typname
-            ),
+            'r' => {
+                let mut script = format!(
+                    "create type {}.{} as range (\n    subtype = {}",
+                    self.schema,
+                    self.typname,
+                    self.range_subtype.as_deref().unwrap_or("unknown")
+                );
+                if let Some(collation) = &self.range_collation {
+                    script.push_str(&format!(",\n    collation = {}", collation));
+                }
+                if let Some(opclass) = &self.range_opclass {
+                    script.push_str(&format!(",\n    subtype_opclass = {}", opclass));
+                }
+                if let Some(canonical) = &self.range_canonical {
+                    script.push_str(&format!(",\n    canonical = {}", canonical));
+                }
+                if let Some(subdiff) = &self.range_subdiff {
+                    script.push_str(&format!(",\n    subtype_diff = {}", subdiff));
+                }
+                if let Some(multirange) = &self.multirange_name {
+                    script.push_str(&format!(",\n    multirange_type_name = {}", multirange));
+                }
+                script.push_str("\n)");
+                script.append_block(";");
+
+                if let Some(comment) = &self.comment {
+                    script.append_block(&format!(
+                        "comment on type {}.{} is '{}';",
+                        self.schema,
+                        self.typname,
+                        escape_single_quotes(comment)
+                    ));
+                }
+
+                script.push_str(&self.get_owner_script());
+
+                script
+            }
+            'm' => {
+                // Multirange types are automatically created with their associated range type.
+                // We just emit a comment, the range type CREATE handles them.
+                let mut script = format!(
+                    "-- Multirange type {}.{} is created automatically with its range type\n",
+                    self.schema, self.typname
+                );
+                if let Some(comment) = &self.comment {
+                    script.append_block(&format!(
+                        "comment on type {}.{} is '{}';",
+                        self.schema,
+                        self.typname,
+                        escape_single_quotes(comment)
+                    ));
+                }
+                script
+            }
             other => format!(
                 "-- Type {}.{} (typtype = {}) is not supported yet\n",
                 self.schema, self.typname, other
@@ -622,14 +707,36 @@ impl PgType {
                     statements.join("\n\n").with_empty_lines()
                 }
             }
-            ('r', 'r') => format!(
-                "-- Altering range type {}.{} is not supported yet.\n",
-                self.schema, self.typname
-            ),
-            ('m', 'm') => format!(
-                "-- Altering multirange type {}.{} is not supported yet.\n",
-                self.schema, self.typname
-            ),
+            ('r', 'r') => {
+                // Range types cannot be altered in place; must be dropped and recreated
+                let drop_script = self.get_drop_script();
+                let create_script = target.get_script();
+                if use_drop {
+                    format!("{}{}", drop_script, create_script)
+                } else {
+                    let commented = format!(
+                        "-- use_drop=false: range type {}.{} requires drop+recreate; statements commented out\n{}{}",
+                        self.schema,
+                        self.typname,
+                        drop_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>(),
+                        create_script
+                            .lines()
+                            .map(|l| format!("-- {}\n", l))
+                            .collect::<String>()
+                    );
+                    commented
+                }
+            }
+            ('m', 'm') => {
+                // Multirange types are auto-managed with range types
+                format!(
+                    "-- Multirange type {}.{} is managed automatically with its range type\n",
+                    self.schema, self.typname
+                )
+            }
             (kind, other) => format!(
                 "-- Alter script not implemented for type {}.{} ({} -> {})\n",
                 self.schema, self.typname, kind, other
@@ -734,6 +841,12 @@ mod tests {
             enum_labels: Vec::new(),
             domain_constraints: Vec::new(),
             composite_attributes: Vec::new(),
+            range_subtype: None,
+            range_collation: None,
+            range_opclass: None,
+            range_canonical: None,
+            range_subdiff: None,
+            multirange_name: None,
             comment: None,
             hash: None,
         }

--- a/app/src/dump/pg_type.rs
+++ b/app/src/dump/pg_type.rs
@@ -186,8 +186,6 @@ impl PgType {
 
         hasher.update(self.schema.as_bytes());
         hasher.update(self.typname.as_bytes());
-        hasher.update(self.typnamespace.0.to_be_bytes());
-        hasher.update(self.typowner.0.to_be_bytes());
         hasher.update(self.owner.as_bytes());
         hasher.update(self.typlen.to_be_bytes());
         hasher.update([self.typbyval as u8]);
@@ -197,17 +195,8 @@ impl PgType {
         hasher.update([self.typisdefined as u8]);
         hasher.update(self.typdelim.to_be_bytes());
 
-        update_option(&mut hasher, &self.typrelid, |hasher, value| {
-            hasher.update(value.0.to_be_bytes());
-        });
         update_option(&mut hasher, &self.typsubscript, |hasher, value| {
             hasher.update(value.as_bytes());
-        });
-        update_option(&mut hasher, &self.typelem, |hasher, value| {
-            hasher.update(value.0.to_be_bytes());
-        });
-        update_option(&mut hasher, &self.typarray, |hasher, value| {
-            hasher.update(value.0.to_be_bytes());
         });
 
         hasher.update(self.typinput.as_bytes());
@@ -233,8 +222,8 @@ impl PgType {
         hasher.update(self.typstorage.to_be_bytes());
         hasher.update([self.typnotnull as u8]);
 
-        update_option(&mut hasher, &self.typbasetype, |hasher, value| {
-            hasher.update(value.0.to_be_bytes());
+        update_option(&mut hasher, &self.formatted_basetype, |hasher, value| {
+            hasher.update(value.as_bytes());
         });
         update_option(&mut hasher, &self.typtypmod, |hasher, value| {
             hasher.update(value.to_be_bytes());
@@ -242,9 +231,6 @@ impl PgType {
 
         hasher.update(self.typndims.to_be_bytes());
 
-        update_option(&mut hasher, &self.typcollation, |hasher, value| {
-            hasher.update(value.0.to_be_bytes());
-        });
         update_option(&mut hasher, &self.typdefault, |hasher, value| {
             hasher.update(value.as_bytes());
         });

--- a/app/src/dump/sequence.rs
+++ b/app/src/dump/sequence.rs
@@ -22,6 +22,8 @@ pub struct Sequence {
     pub owned_by_column: Option<String>, // Owning column name
     pub is_identity: bool,               // Whether the sequence is an identity sequence
     #[serde(default)]
+    pub is_unlogged: bool, // Whether the sequence is unlogged (relpersistence = 'u')
+    #[serde(default)]
     pub comment: Option<String>, // Optional sequence comment
     pub hash: Option<String>,            // Hash of the sequence
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -63,6 +65,7 @@ impl Sequence {
             owned_by_table,
             owned_by_column,
             is_identity: false,
+            is_unlogged: false,
             comment: None,
             hash: None,
             acl: Vec::new(),
@@ -101,6 +104,7 @@ impl Sequence {
             hasher.update(cache_size.to_string().as_bytes());
         }
         hasher.update(self.is_identity.to_string().as_bytes());
+        hasher.update(self.is_unlogged.to_string().as_bytes());
         if let Some(comment) = &self.comment {
             hasher.update(comment.as_bytes());
         }
@@ -129,7 +133,14 @@ impl Sequence {
         let mut script = String::new();
 
         // CREATE SEQUENCE statement
-        script.push_str(&format!("create sequence {}.{}", self.schema, self.name));
+        if self.is_unlogged {
+            script.push_str(&format!(
+                "create unlogged sequence {}.{}",
+                self.schema, self.name
+            ));
+        } else {
+            script.push_str(&format!("create sequence {}.{}", self.schema, self.name));
+        }
 
         // Add AS clause for data type if not default
         if !self.data_type.is_empty() && self.data_type != "bigint" {
@@ -215,6 +226,20 @@ impl Sequence {
     pub fn get_alter_script(&self, from: &Sequence) -> String {
         let mut clauses = Vec::new();
 
+        // Handle logged/unlogged change
+        let mut logging_script = String::new();
+        if self.is_unlogged != from.is_unlogged {
+            if self.is_unlogged {
+                logging_script =
+                    format!("alter sequence {}.{} set unlogged;", self.schema, self.name)
+                        .with_empty_lines();
+            } else {
+                logging_script =
+                    format!("alter sequence {}.{} set logged;", self.schema, self.name)
+                        .with_empty_lines();
+            }
+        }
+
         if let Some(start_value) = self.start_value {
             clauses.push(format!("start with {start_value}"));
             // Emit RESTART WITH only when the effective current position (last_value if
@@ -253,7 +278,8 @@ impl Sequence {
             clauses.push(owned_by);
         }
 
-        let mut script = format!("alter sequence {}.{}", self.schema, self.name);
+        let mut script = logging_script;
+        script.push_str(&format!("alter sequence {}.{}", self.schema, self.name));
 
         if !clauses.is_empty() {
             script.push(' ');
@@ -327,7 +353,8 @@ mod tests {
         hasher.update("5".as_bytes());
         hasher.update("true".as_bytes());
         hasher.update("20".as_bytes());
-        hasher.update("false".as_bytes());
+        hasher.update("false".as_bytes()); // is_identity
+        hasher.update("false".as_bytes()); // is_unlogged
 
         let expected_hash = format!("{:x}", hasher.finalize());
 

--- a/app/src/dump/statistic.rs
+++ b/app/src/dump/statistic.rs
@@ -124,7 +124,7 @@ impl Statistic {
     /// Returns an ALTER script to transform self into target.
     /// Extended statistics objects can't be altered in place for definition changes;
     /// they must be dropped and recreated.
-    pub fn get_alter_script(&self, target: &Statistic) -> String {
+    pub fn get_alter_script(&self, target: &Statistic, use_drop: bool) -> String {
         let mut statements = Vec::new();
 
         // Owner change
@@ -144,7 +144,24 @@ impl Statistic {
             || self.table_schema != target.table_schema
             || self.table_name != target.table_name
         {
-            return format!("{}{}", self.get_drop_script(), target.get_script());
+            let drop = self.get_drop_script();
+            let create = target.get_script();
+            if use_drop {
+                return format!("{}{}", drop, create);
+            } else {
+                let commented_drop = drop
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                let commented_create = create
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>();
+                return format!(
+                    "-- use_drop=false: statistics {}.{} requires drop+recreate; statements commented out\n{}{}",
+                    self.schema, self.name, commented_drop, commented_create
+                );
+            }
         }
 
         // Comment change
@@ -250,7 +267,7 @@ mod tests {
         let s1 = make_statistic();
         let mut s2 = make_statistic();
         s2.owner = "new_owner".to_string();
-        let script = s1.get_alter_script(&s2);
+        let script = s1.get_alter_script(&s2, true);
         assert!(script.contains("alter statistics public.my_stat owner to new_owner;"));
     }
 
@@ -263,7 +280,7 @@ mod tests {
                 .to_string();
         s2.kinds = vec!["mcv".to_string()];
         s2.columns = vec!["col1".to_string(), "col2".to_string(), "col3".to_string()];
-        let script = s1.get_alter_script(&s2);
+        let script = s1.get_alter_script(&s2, true);
         assert!(script.contains("drop statistics if exists public.my_stat;"));
         assert!(script.contains("create statistics public.my_stat"));
     }
@@ -273,7 +290,7 @@ mod tests {
         let s1 = make_statistic();
         let mut s2 = make_statistic();
         s2.comment = Some("new comment".to_string());
-        let script = s1.get_alter_script(&s2);
+        let script = s1.get_alter_script(&s2, true);
         assert!(script.contains("comment on statistics public.my_stat is 'new comment';"));
     }
 
@@ -281,7 +298,20 @@ mod tests {
     fn get_alter_script_no_changes() {
         let s1 = make_statistic();
         let s2 = make_statistic();
-        let script = s1.get_alter_script(&s2);
+        let script = s1.get_alter_script(&s2, true);
         assert!(script.is_empty());
+    }
+
+    #[test]
+    fn get_alter_script_definition_change_use_drop_false_comments_out() {
+        let s1 = make_statistic();
+        let mut s2 = make_statistic();
+        s2.kinds = vec!["mcv".to_string()];
+        s2.columns = vec!["col1".to_string(), "col2".to_string(), "col3".to_string()];
+        let script = s1.get_alter_script(&s2, false);
+        assert!(script.contains("-- use_drop=false"));
+        assert!(script.contains("-- drop statistics"));
+        assert!(script.contains("-- create statistics"));
+        assert!(!script.contains("\ndrop statistics"));
     }
 }

--- a/app/src/dump/statistic.rs
+++ b/app/src/dump/statistic.rs
@@ -59,7 +59,6 @@ impl Statistic {
         hasher.update(self.owner.as_bytes());
         hasher.update(self.table_schema.as_bytes());
         hasher.update(self.table_name.as_bytes());
-        hasher.update(self.definition.as_bytes());
 
         hasher.update((self.kinds.len() as u32).to_be_bytes());
         for kind in &self.kinds {
@@ -139,8 +138,12 @@ impl Statistic {
             );
         }
 
-        // If the definition changed, drop and recreate
-        if self.definition != target.definition {
+        // If the structural definition changed, drop and recreate
+        if self.kinds != target.kinds
+            || self.columns != target.columns
+            || self.table_schema != target.table_schema
+            || self.table_name != target.table_name
+        {
             return format!("{}{}", self.get_drop_script(), target.get_script());
         }
 

--- a/app/src/dump/statistic.rs
+++ b/app/src/dump/statistic.rs
@@ -1,0 +1,284 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::utils::string_extensions::StringExt;
+
+/// Information about a PostgreSQL extended statistics object (CREATE STATISTICS).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Statistic {
+    pub schema: String,
+    pub name: String,
+    pub owner: String,
+    /// The target table schema.
+    pub table_schema: String,
+    /// The target table name.
+    pub table_name: String,
+    /// The statistics kinds (e.g., "ndistinct", "dependencies", "mcv").
+    pub kinds: Vec<String>,
+    /// The column/expression definitions.
+    pub columns: Vec<String>,
+    /// The full definition as returned by pg_get_statisticsobjdef.
+    pub definition: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    pub hash: Option<String>,
+}
+
+impl Statistic {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        schema: String,
+        name: String,
+        owner: String,
+        table_schema: String,
+        table_name: String,
+        kinds: Vec<String>,
+        columns: Vec<String>,
+        definition: String,
+    ) -> Self {
+        let mut stat = Self {
+            schema,
+            name,
+            owner,
+            table_schema,
+            table_name,
+            kinds,
+            columns,
+            definition,
+            comment: None,
+            hash: None,
+        };
+        stat.hash();
+        stat
+    }
+
+    pub fn hash(&mut self) {
+        let mut hasher = Sha256::new();
+        hasher.update(self.schema.as_bytes());
+        hasher.update(self.name.as_bytes());
+        hasher.update(self.owner.as_bytes());
+        hasher.update(self.table_schema.as_bytes());
+        hasher.update(self.table_name.as_bytes());
+        hasher.update(self.definition.as_bytes());
+
+        hasher.update((self.kinds.len() as u32).to_be_bytes());
+        for kind in &self.kinds {
+            hasher.update(kind.as_bytes());
+        }
+
+        hasher.update((self.columns.len() as u32).to_be_bytes());
+        for col in &self.columns {
+            hasher.update(col.as_bytes());
+        }
+
+        if let Some(comment) = &self.comment {
+            hasher.update((comment.len() as u32).to_be_bytes());
+            hasher.update(comment.as_bytes());
+        }
+
+        self.hash = Some(format!("{:x}", hasher.finalize()));
+    }
+
+    /// Returns a CREATE STATISTICS script.
+    pub fn get_script(&self) -> String {
+        let mut result = format!(
+            "create statistics {}.{} ({}) on {} from {}.{};",
+            self.schema,
+            self.name,
+            self.kinds.join(", "),
+            self.columns.join(", "),
+            self.table_schema,
+            self.table_name
+        )
+        .with_empty_lines();
+
+        if !self.owner.is_empty() {
+            result.push_str(
+                &format!(
+                    "alter statistics {}.{} owner to {};",
+                    self.schema, self.name, self.owner
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        if let Some(comment) = &self.comment {
+            result.push_str(
+                &format!(
+                    "comment on statistics {}.{} is '{}';",
+                    self.schema,
+                    self.name,
+                    comment.replace('\'', "''")
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        result
+    }
+
+    /// Returns a DROP STATISTICS script.
+    pub fn get_drop_script(&self) -> String {
+        format!("drop statistics if exists {}.{};", self.schema, self.name).with_empty_lines()
+    }
+
+    /// Returns an ALTER script to transform self into target.
+    /// Extended statistics objects can't be altered in place for definition changes;
+    /// they must be dropped and recreated.
+    pub fn get_alter_script(&self, target: &Statistic) -> String {
+        let mut statements = Vec::new();
+
+        // Owner change
+        if self.owner != target.owner && !target.owner.is_empty() {
+            statements.push(
+                format!(
+                    "alter statistics {}.{} owner to {};",
+                    target.schema, target.name, target.owner
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        // If the definition changed, drop and recreate
+        if self.definition != target.definition {
+            return format!("{}{}", self.get_drop_script(), target.get_script());
+        }
+
+        // Comment change
+        if self.comment != target.comment {
+            if let Some(comment) = &target.comment {
+                statements.push(
+                    format!(
+                        "comment on statistics {}.{} is '{}';",
+                        target.schema,
+                        target.name,
+                        comment.replace('\'', "''")
+                    )
+                    .with_empty_lines(),
+                );
+            } else {
+                statements.push(
+                    format!(
+                        "comment on statistics {}.{} is null;",
+                        target.schema, target.name
+                    )
+                    .with_empty_lines(),
+                );
+            }
+        }
+
+        statements.join("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_statistic() -> Statistic {
+        Statistic::new(
+            "public".to_string(),
+            "my_stat".to_string(),
+            "postgres".to_string(),
+            "public".to_string(),
+            "my_table".to_string(),
+            vec!["ndistinct".to_string(), "dependencies".to_string()],
+            vec!["col1".to_string(), "col2".to_string()],
+            "CREATE STATISTICS public.my_stat (ndistinct, dependencies) ON col1, col2 FROM public.my_table".to_string(),
+        )
+    }
+
+    #[test]
+    fn hash_populates_hash_field() {
+        let stat = make_statistic();
+        assert!(stat.hash.is_some());
+    }
+
+    #[test]
+    fn hash_is_consistent() {
+        let s1 = make_statistic();
+        let s2 = make_statistic();
+        assert_eq!(s1.hash, s2.hash);
+    }
+
+    #[test]
+    fn hash_differs_with_different_name() {
+        let s1 = make_statistic();
+        let mut s2 = make_statistic();
+        s2.name = "other_stat".to_string();
+        s2.hash();
+        assert_ne!(s1.hash, s2.hash);
+    }
+
+    #[test]
+    fn get_script_creates_statistics() {
+        let stat = make_statistic();
+        let script = stat.get_script();
+        assert!(script.contains("create statistics public.my_stat"));
+        assert!(script.contains("(ndistinct, dependencies)"));
+        assert!(script.contains("on col1, col2"));
+        assert!(script.contains("from public.my_table"));
+    }
+
+    #[test]
+    fn get_script_includes_owner() {
+        let stat = make_statistic();
+        let script = stat.get_script();
+        assert!(script.contains("alter statistics public.my_stat owner to postgres;"));
+    }
+
+    #[test]
+    fn get_script_includes_comment() {
+        let mut stat = make_statistic();
+        stat.comment = Some("test comment".to_string());
+        let script = stat.get_script();
+        assert!(script.contains("comment on statistics public.my_stat is 'test comment';"));
+    }
+
+    #[test]
+    fn get_drop_script() {
+        let stat = make_statistic();
+        let script = stat.get_drop_script();
+        assert!(script.contains("drop statistics if exists public.my_stat;"));
+    }
+
+    #[test]
+    fn get_alter_script_owner_change() {
+        let s1 = make_statistic();
+        let mut s2 = make_statistic();
+        s2.owner = "new_owner".to_string();
+        let script = s1.get_alter_script(&s2);
+        assert!(script.contains("alter statistics public.my_stat owner to new_owner;"));
+    }
+
+    #[test]
+    fn get_alter_script_definition_change_drops_recreates() {
+        let s1 = make_statistic();
+        let mut s2 = make_statistic();
+        s2.definition =
+            "CREATE STATISTICS public.my_stat (mcv) ON col1, col2, col3 FROM public.my_table"
+                .to_string();
+        s2.kinds = vec!["mcv".to_string()];
+        s2.columns = vec!["col1".to_string(), "col2".to_string(), "col3".to_string()];
+        let script = s1.get_alter_script(&s2);
+        assert!(script.contains("drop statistics if exists public.my_stat;"));
+        assert!(script.contains("create statistics public.my_stat"));
+    }
+
+    #[test]
+    fn get_alter_script_comment_change() {
+        let s1 = make_statistic();
+        let mut s2 = make_statistic();
+        s2.comment = Some("new comment".to_string());
+        let script = s1.get_alter_script(&s2);
+        assert!(script.contains("comment on statistics public.my_stat is 'new comment';"));
+    }
+
+    #[test]
+    fn get_alter_script_no_changes() {
+        let s1 = make_statistic();
+        let s2 = make_statistic();
+        let script = s1.get_alter_script(&s2);
+        assert!(script.is_empty());
+    }
+}

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -107,6 +107,8 @@ pub struct Table {
     pub hash: Option<String>,              // Hash of the table
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub acl: Vec<String>, // ACL (grant) entries for this table
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_method: Option<String>, // Table access method (e.g., "heap", custom AM)
 }
 
 impl Table {
@@ -148,6 +150,7 @@ impl Table {
             comment: None,
             hash: None,
             acl: Vec::new(),
+            access_method: None,
         };
         table.hash();
         table
@@ -161,14 +164,19 @@ impl Table {
     ///
     /// `has_tabledef_fn` should be pre-checked once per dump run so we don't
     /// repeat the `pg_proc` lookup for every table.
-    pub async fn fill(&mut self, pool: &PgPool, has_tabledef_fn: bool) -> Result<(), Error> {
+    pub async fn fill(
+        &mut self,
+        pool: &PgPool,
+        has_tabledef_fn: bool,
+        pg_version: i32,
+    ) -> Result<(), Error> {
         let raw_schema = self.raw_schema.clone();
         let raw_name = self.raw_name.clone();
 
         let (columns, indexes, constraints, triggers, policies_data, partition, definition) = tokio::try_join!(
-            Self::fetch_columns(pool, &raw_schema, &raw_name),
+            Self::fetch_columns(pool, &raw_schema, &raw_name, pg_version),
             Self::fetch_indexes(pool, &raw_schema, &raw_name),
-            Self::fetch_constraints(pool, &raw_schema, &raw_name),
+            Self::fetch_constraints(pool, &raw_schema, &raw_name, pg_version),
             Self::fetch_triggers(pool, &raw_schema, &raw_name),
             Self::fetch_policies(pool, &raw_schema, &raw_name),
             Self::fetch_partition_info(pool, &raw_schema, &raw_name),
@@ -199,7 +207,13 @@ impl Table {
         pool: &PgPool,
         schema: &str,
         name: &str,
+        pg_version: i32,
     ) -> Result<Vec<TableColumn>, Error> {
+        let compression_col = if pg_version >= 140000 {
+            ",\n                                a.attcompression::text as col_compression"
+        } else {
+            ""
+        };
         let query = format!(
                         "SELECT
                                 c.table_catalog,
@@ -249,8 +263,10 @@ impl Table {
                                 c.identity_cycle,
                                 c.is_generated,
                                 c.generation_expression,
+                                a.attgenerated::text as attgenerated,
+                                a.attstorage::text as col_storage,
                                 c.is_updatable,
-                                pd.description as column_comment,
+                                pd.description as column_comment{compression_col},
                                 (
                                         SELECT string_agg(DISTINCT rel, ', ')
                                         FROM (
@@ -344,6 +360,10 @@ impl Table {
                     identity_cycle: row.get::<&str, _>("identity_cycle") == "YES", // Convert to boolean
                     is_generated: row.get("is_generated"),
                     generation_expression: row.get("generation_expression"),
+                    generation_type: {
+                        let ag: String = row.get("attgenerated");
+                        if ag.is_empty() { None } else { Some(ag) }
+                    },
                     is_updatable: row.get::<&str, _>("is_updatable") == "YES", // Convert to boolean
                     related_views: row.get::<Option<String>, _>("related_views").map(|s| {
                         let mut views: Vec<String> =
@@ -352,6 +372,26 @@ impl Table {
                         views
                     }),
                     comment: row.get("column_comment"),
+                    storage: {
+                        let s: String = row.get("col_storage");
+                        match s.as_str() {
+                            "p" => Some("PLAIN".to_string()),
+                            "e" => Some("EXTERNAL".to_string()),
+                            "m" => Some("MAIN".to_string()),
+                            "x" => Some("EXTENDED".to_string()),
+                            _ => None,
+                        }
+                    },
+                    compression: if pg_version >= 140000 {
+                        let c: String = row.get("col_compression");
+                        match c.as_str() {
+                            "p" => Some("pglz".to_string()),
+                            "l" => Some("lz4".to_string()),
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    },
                     serial_type: None,
                 };
 
@@ -418,7 +458,24 @@ impl Table {
         pool: &PgPool,
         schema: &str,
         name: &str,
+        pg_version: i32,
     ) -> Result<Vec<TableConstraint>, Error> {
+        let conenforced_col = if pg_version >= 180000 {
+            ",\n                c.conenforced AS is_enforced"
+        } else {
+            ""
+        };
+        let connullsnotdistinct_col = if pg_version >= 150000 {
+            ",\n                coalesce(c.connullsnotdistinct, false) AS nulls_not_distinct"
+        } else {
+            ""
+        };
+        // PG18 stores named NOT NULL constraints in pg_constraint as contype = 'n'.
+        let contype_filter = if pg_version >= 180000 {
+            "('p','u','f','c','x','n')"
+        } else {
+            "('p','u','f','c','x')"
+        };
         let query = format!(
             "SELECT
                 current_database() AS catalog,
@@ -430,12 +487,14 @@ impl Table {
                     WHEN 'f' THEN 'FOREIGN KEY'
                     WHEN 'u' THEN 'UNIQUE'
                     WHEN 'c' THEN 'CHECK'
+                    WHEN 'x' THEN 'EXCLUDE'
+                    WHEN 'n' THEN 'NOT NULL'
                     ELSE c.contype::text
                 END AS constraint_type,
                 c.condeferrable AS is_deferrable,
                 c.condeferred AS initially_deferred,
                 pg_get_constraintdef(c.oid, true) AS definition,
-                c.coninhcount::int4 AS coninhcount
+                c.coninhcount::int4 AS coninhcount,\n                c.connoinherit AS no_inherit{conenforced_col}{connullsnotdistinct_col}
             FROM
                 pg_constraint c
                 JOIN pg_class t ON t.oid = c.conrelid
@@ -443,7 +502,7 @@ impl Table {
                 WHERE
                     n.nspname = '{}' AND
                     t.relname = '{}' AND
-                    c.contype IN ('p','u','f','c') AND
+                    c.contype IN {contype_filter} AND
                     c.conislocal
                 ORDER BY
                     n.nspname,
@@ -467,6 +526,9 @@ impl Table {
                 initially_deferred: row.get("initially_deferred"),
                 definition: row.get("definition"),
                 coninhcount: row.get("coninhcount"),
+                is_enforced: row.try_get("is_enforced").unwrap_or(true),
+                no_inherit: row.get("no_inherit"),
+                nulls_not_distinct: row.try_get("nulls_not_distinct").unwrap_or(false),
             });
         }
 
@@ -693,6 +755,9 @@ impl Table {
         if let Some(cmt) = &self.comment {
             hasher.update(cmt.as_bytes());
         }
+        if let Some(am) = &self.access_method {
+            hasher.update(am.as_bytes());
+        }
 
         self.hash = Some(format!("{:x}", hasher.finalize()));
     }
@@ -805,32 +870,45 @@ impl Table {
                     && let Some(end) = pk_constraint[start + 1..].find(')')
                 {
                     let cols_part = &pk_constraint[start + 1..start + 1 + end];
-                    let pk_cols: Vec<&str> = cols_part
-                        .split(',')
-                        .map(|c| c.trim().trim_matches('"'))
-                        .collect();
-                    if !pk_cols.is_empty() {
+                    // For temporal PKs with WITHOUT OVERLAPS, preserve the raw definition
+                    if cols_part.to_lowercase().contains("without overlaps") {
                         let pk_def = if pk_constraint_name.is_empty() {
-                            format!(
-                                "    primary key ({})",
-                                pk_cols
-                                    .iter()
-                                    .map(|c| format!("\"{c}\""))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            )
+                            format!("    primary key ({cols_part})")
                         } else {
                             format!(
-                                "    constraint {} primary key ({})",
-                                pk_constraint_name,
-                                pk_cols
-                                    .iter()
-                                    .map(|c| format!("\"{c}\""))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
+                                "    constraint {} primary key ({cols_part})",
+                                pk_constraint_name
                             )
                         };
                         column_definitions.push(pk_def);
+                    } else {
+                        let pk_cols: Vec<&str> = cols_part
+                            .split(',')
+                            .map(|c| c.trim().trim_matches('"'))
+                            .collect();
+                        if !pk_cols.is_empty() {
+                            let pk_def = if pk_constraint_name.is_empty() {
+                                format!(
+                                    "    primary key ({})",
+                                    pk_cols
+                                        .iter()
+                                        .map(|c| format!("\"{c}\""))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                )
+                            } else {
+                                format!(
+                                    "    constraint {} primary key ({})",
+                                    pk_constraint_name,
+                                    pk_cols
+                                        .iter()
+                                        .map(|c| format!("\"{c}\""))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                )
+                            };
+                            column_definitions.push(pk_def);
+                        }
                     }
                 }
             }
@@ -843,6 +921,10 @@ impl Table {
                 script.push_str(&format!("\npartition by {}", partition_key));
             }
 
+            if let Some(am) = &self.access_method {
+                script.push_str(&format!("\nusing {}", am));
+            }
+
             if let Some(space) = &self.space {
                 script.push_str(&format!("\ntablespace {}", quote_ident(space)));
             }
@@ -850,11 +932,29 @@ impl Table {
             script.append_block(";");
         }
 
-        // 5. Add other constraints (excluding primary key and foreign key)
+        // 5. Add other constraints (excluding primary key, foreign key, and NOT NULL)
+        // NOT NULL constraints are already expressed in column definitions.
         for constraint in &self.constraints {
             let c_type = constraint.constraint_type.to_lowercase();
-            if c_type != "primary key" && c_type != "foreign key" {
+            if c_type != "primary key" && c_type != "foreign key" && c_type != "not null" {
                 script.push_str(&constraint.get_script());
+            }
+        }
+
+        // 5a. Emit SET STORAGE / SET COMPRESSION for columns with non-default values
+        for column in &self.columns {
+            if let Some(storage) = &column.storage {
+                // EXTENDED is the default for most varlena types; always emit to be explicit
+                script.append_block(&format!(
+                    "alter table {}.{} alter column {} set storage {};",
+                    self.schema, self.name, column.name, storage
+                ));
+            }
+            if let Some(compression) = &column.compression {
+                script.append_block(&format!(
+                    "alter table {}.{} alter column {} set compression {};",
+                    self.schema, self.name, column.name, compression
+                ));
             }
         }
 
@@ -1351,6 +1451,20 @@ impl Table {
             script.push_str(&to_table.get_owner_script());
         }
 
+        if self.access_method != to_table.access_method {
+            if let Some(am) = &to_table.access_method {
+                script.append_block(&format!(
+                    "alter table {}.{} set access method {};",
+                    to_table.schema, to_table.name, am
+                ));
+            } else {
+                script.append_block(&format!(
+                    "alter table {}.{} set access method heap;",
+                    to_table.schema, to_table.name
+                ));
+            }
+        }
+
         if self.space != to_table.space
             && let Some(new_space) = &to_table.space
         {
@@ -1474,9 +1588,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         }
     }
@@ -1525,6 +1642,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -1539,6 +1659,9 @@ mod tests {
             initially_deferred: false,
             definition: Some(definition.to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -1553,6 +1676,9 @@ mod tests {
             initially_deferred,
             definition: Some("FOREIGN KEY (account_id) REFERENCES public.accounts(id)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -1567,6 +1693,9 @@ mod tests {
             initially_deferred: false,
             definition: Some(definition.to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -2003,6 +2132,9 @@ mod tests {
             initially_deferred: false,
             definition: Some(definition.to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -2296,9 +2428,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         }
     }
@@ -2734,6 +2869,9 @@ mod tests {
             initially_deferred: false,
             definition: definition.map(|d| d.to_string()),
             coninhcount: 1,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -2988,6 +3126,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("FOREIGN KEY (account_id) REFERENCES public.accounts(id)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let to = partition_child_table(
             vec![partition_child_identity_column("id", 1, "integer")],
@@ -3152,6 +3293,9 @@ mod tests {
             initially_deferred: false,
             definition: definition.map(|d| d.to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -3541,5 +3685,200 @@ mod tests {
         // A column actually named "list" inside the key should be extracted
         let ids = extract_partition_key_identifiers("range (list)");
         assert_eq!(ids, vec!["list"]);
+    }
+
+    // ---- PG18: WITHOUT OVERLAPS temporal constraint tests ----
+
+    #[test]
+    fn test_get_script_temporal_pk_without_overlaps() {
+        let table = Table::new(
+            "public".to_string(),
+            "reservations".to_string(),
+            "public".to_string(),
+            "reservations".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                {
+                    let mut c = base_column("id", 1);
+                    c.data_type = "integer".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+                {
+                    let mut c = base_column("valid_range", 2);
+                    c.table = "reservations".to_string();
+                    c.data_type = "tsrange".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+            ],
+            vec![TableConstraint {
+                catalog: "postgres".to_string(),
+                schema: "public".to_string(),
+                name: "reservations_pkey".to_string(),
+                table_name: "reservations".to_string(),
+                constraint_type: "PRIMARY KEY".to_string(),
+                is_deferrable: false,
+                initially_deferred: false,
+                definition: Some("PRIMARY KEY (id, valid_range WITHOUT OVERLAPS)".to_string()),
+                coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
+            }],
+            vec![],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("primary key (id, valid_range WITHOUT OVERLAPS)"),
+            "expected WITHOUT OVERLAPS in PK definition: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_script_temporal_pk_named_constraint_without_overlaps() {
+        let table = Table::new(
+            "public".to_string(),
+            "bookings".to_string(),
+            "public".to_string(),
+            "bookings".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                {
+                    let mut c = base_column("room_id", 1);
+                    c.data_type = "integer".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+                {
+                    let mut c = base_column("period", 2);
+                    c.table = "bookings".to_string();
+                    c.data_type = "tsrange".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+            ],
+            vec![TableConstraint {
+                catalog: "postgres".to_string(),
+                schema: "public".to_string(),
+                name: "bookings_pk".to_string(),
+                table_name: "bookings".to_string(),
+                constraint_type: "PRIMARY KEY".to_string(),
+                is_deferrable: false,
+                initially_deferred: false,
+                definition: Some("PRIMARY KEY (room_id, period WITHOUT OVERLAPS)".to_string()),
+                coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
+            }],
+            vec![],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script
+                .contains("constraint bookings_pk primary key (room_id, period WITHOUT OVERLAPS)"),
+            "expected named constraint with WITHOUT OVERLAPS: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_script_not_enforced_constraint_in_table() {
+        let table = Table::new(
+            "public".to_string(),
+            "orders".to_string(),
+            "public".to_string(),
+            "orders".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                {
+                    let mut c = base_column("id", 1);
+                    c.data_type = "integer".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+                {
+                    let mut c = base_column("status", 2);
+                    c.data_type = "text".to_string();
+                    c
+                },
+            ],
+            vec![TableConstraint {
+                catalog: "postgres".to_string(),
+                schema: "public".to_string(),
+                name: "chk_status".to_string(),
+                table_name: "orders".to_string(),
+                constraint_type: "CHECK".to_string(),
+                is_deferrable: false,
+                initially_deferred: false,
+                definition: Some("CHECK (status <> '')".to_string()),
+                coninhcount: 0,
+                is_enforced: false,
+                no_inherit: false,
+                nulls_not_distinct: false,
+            }],
+            vec![],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("not enforced"),
+            "expected NOT ENFORCED check constraint in table script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_script_virtual_generated_column_in_table() {
+        let table = Table::new(
+            "public".to_string(),
+            "products".to_string(),
+            "public".to_string(),
+            "products".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![
+                {
+                    let mut c = base_column("price", 1);
+                    c.data_type = "numeric".to_string();
+                    c.is_nullable = false;
+                    c
+                },
+                {
+                    let mut c = base_column("qty", 2);
+                    c.data_type = "integer".to_string();
+                    c
+                },
+                {
+                    let mut c = base_column("total", 3);
+                    c.table = "products".to_string();
+                    c.data_type = "numeric".to_string();
+                    c.is_generated = "ALWAYS".to_string();
+                    c.generation_expression = Some("(price * qty)".to_string());
+                    c.generation_type = Some("v".to_string());
+                    c
+                },
+            ],
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("generated always as (price * qty) virtual"),
+            "expected virtual generated column in table script: {script}"
+        );
     }
 }

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -435,7 +435,7 @@ impl Table {
                 c.condeferrable AS is_deferrable,
                 c.condeferred AS initially_deferred,
                 pg_get_constraintdef(c.oid, true) AS definition,
-                c.coninhcount
+                c.coninhcount::int4 AS coninhcount
             FROM
                 pg_constraint c
                 JOIN pg_class t ON t.oid = c.conrelid

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -209,7 +209,14 @@ impl Table {
         name: &str,
         pg_version: i32,
     ) -> Result<Vec<TableColumn>, Error> {
-        let compression_col = if pg_version >= 140000 {
+        let has_attcompression: bool = pg_version >= 140000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_attribute'::regclass AND attname = 'attcompression' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+        let compression_col = if has_attcompression {
             ",\n                                a.attcompression::text as col_compression"
         } else {
             ""
@@ -382,7 +389,7 @@ impl Table {
                             _ => None,
                         }
                     },
-                    compression: if pg_version >= 140000 {
+                    compression: if has_attcompression {
                         let c: String = row.get("col_compression");
                         match c.as_str() {
                             "p" => Some("pglz".to_string()),
@@ -422,9 +429,10 @@ impl Table {
                          JOIN pg_class ic ON ic.relname = i.indexname
                          JOIN pg_namespace n ON n.oid = ic.relnamespace AND n.nspname = i.schemaname
                          JOIN pg_index idx ON idx.indexrelid = ic.oid
-                         LEFT JOIN pg_constraint con ON con.conindid = ic.oid AND con.contype IN ('p', 'u')
+                         LEFT JOIN pg_constraint puc ON puc.conindid = ic.oid AND puc.contype IN ('p', 'u')
                          WHERE idx.indisprimary = false
-                             AND (idx.indisunique = false OR con.oid IS NULL)
+                             AND (idx.indisunique = false OR puc.oid IS NULL)
+                             AND NOT EXISTS (SELECT 1 FROM pg_constraint xc WHERE xc.conindid = ic.oid AND xc.contype = 'x')
                              AND i.schemaname = '{}' AND i.tablename = '{}'
                          ORDER BY i.schemaname, i.tablename, i.indexname",
                         escape_single_quotes(schema),
@@ -460,12 +468,26 @@ impl Table {
         name: &str,
         pg_version: i32,
     ) -> Result<Vec<TableConstraint>, Error> {
-        let conenforced_col = if pg_version >= 180000 {
+        let has_conenforced: bool = pg_version >= 180000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'conenforced' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+        let conenforced_col = if has_conenforced {
             ",\n                c.conenforced AS is_enforced"
         } else {
             ""
         };
-        let connullsnotdistinct_col = if pg_version >= 150000 {
+        let has_connullsnotdistinct: bool = pg_version >= 150000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'connullsnotdistinct' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+        let connullsnotdistinct_col = if has_connullsnotdistinct {
             ",\n                coalesce(c.connullsnotdistinct, false) AS nulls_not_distinct"
         } else {
             ""

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -8,6 +8,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sqlx::{Error, PgPool, Row};
+use std::collections::HashMap;
 
 fn escape_single_quotes(value: &str) -> String {
     value.replace('\'', "''")
@@ -77,6 +78,57 @@ fn extract_partition_key_identifiers(pk: &str) -> Vec<String> {
         }
     }
     identifiers
+}
+
+/// Pre-computed catalog capability flags.
+///
+/// These booleans indicate whether certain columns / features exist in the
+/// connected PostgreSQL server's system catalogs.  They are probed **once**
+/// per dump run (via [`PgCatalogCaps::detect`]) and then threaded into every
+/// per-table fetch function, avoiding a repeated `EXISTS` query per table.
+#[derive(Debug, Clone, Copy)]
+pub struct PgCatalogCaps {
+    /// pg_attribute.attcompression exists (PG 14+)
+    pub has_attcompression: bool,
+    /// pg_constraint.conenforced exists (PG 18+)
+    pub has_conenforced: bool,
+    /// pg_constraint.connullsnotdistinct exists (PG 15+)
+    pub has_connullsnotdistinct: bool,
+}
+
+impl PgCatalogCaps {
+    /// Probe the catalog once and return the capability flags.
+    pub async fn detect(pool: &PgPool, pg_version: i32) -> Self {
+        let has_attcompression = pg_version >= 140000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_attribute'::regclass AND attname = 'attcompression' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+
+        let has_conenforced = pg_version >= 180000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'conenforced' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+
+        let has_connullsnotdistinct = pg_version >= 150000
+            && sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'connullsnotdistinct' AND NOT attisdropped)",
+            )
+            .fetch_one(pool)
+            .await
+            .unwrap_or(false);
+
+        Self {
+            has_attcompression,
+            has_conenforced,
+            has_connullsnotdistinct,
+        }
+    }
 }
 
 // This is an information about a PostgreSQL table.
@@ -164,19 +216,23 @@ impl Table {
     ///
     /// `has_tabledef_fn` should be pre-checked once per dump run so we don't
     /// repeat the `pg_proc` lookup for every table.
+    ///
+    /// `caps` carries pre-computed catalog capability flags so that per-table
+    /// fetches never issue redundant `EXISTS` probes.
     pub async fn fill(
         &mut self,
         pool: &PgPool,
         has_tabledef_fn: bool,
         pg_version: i32,
+        caps: PgCatalogCaps,
     ) -> Result<(), Error> {
         let raw_schema = self.raw_schema.clone();
         let raw_name = self.raw_name.clone();
 
         let (columns, indexes, constraints, triggers, policies_data, partition, definition) = tokio::try_join!(
-            Self::fetch_columns(pool, &raw_schema, &raw_name, pg_version),
+            Self::fetch_columns(pool, &raw_schema, &raw_name, caps),
             Self::fetch_indexes(pool, &raw_schema, &raw_name),
-            Self::fetch_constraints(pool, &raw_schema, &raw_name, pg_version),
+            Self::fetch_constraints(pool, &raw_schema, &raw_name, pg_version, caps),
             Self::fetch_triggers(pool, &raw_schema, &raw_name),
             Self::fetch_policies(pool, &raw_schema, &raw_name),
             Self::fetch_partition_info(pool, &raw_schema, &raw_name),
@@ -207,16 +263,9 @@ impl Table {
         pool: &PgPool,
         schema: &str,
         name: &str,
-        pg_version: i32,
+        caps: PgCatalogCaps,
     ) -> Result<Vec<TableColumn>, Error> {
-        let has_attcompression: bool = pg_version >= 140000
-            && sqlx::query_scalar::<_, bool>(
-                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_attribute'::regclass AND attname = 'attcompression' AND NOT attisdropped)",
-            )
-            .fetch_one(pool)
-            .await
-            .unwrap_or(false);
-        let compression_col = if has_attcompression {
+        let compression_col = if caps.has_attcompression {
             ",\n                                a.attcompression::text as col_compression"
         } else {
             ""
@@ -389,7 +438,7 @@ impl Table {
                             _ => None,
                         }
                     },
-                    compression: if has_attcompression {
+                    compression: if caps.has_attcompression {
                         let c: String = row.get("col_compression");
                         match c.as_str() {
                             "p" => Some("pglz".to_string()),
@@ -467,27 +516,14 @@ impl Table {
         schema: &str,
         name: &str,
         pg_version: i32,
+        caps: PgCatalogCaps,
     ) -> Result<Vec<TableConstraint>, Error> {
-        let has_conenforced: bool = pg_version >= 180000
-            && sqlx::query_scalar::<_, bool>(
-                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'conenforced' AND NOT attisdropped)",
-            )
-            .fetch_one(pool)
-            .await
-            .unwrap_or(false);
-        let conenforced_col = if has_conenforced {
+        let conenforced_col = if caps.has_conenforced {
             ",\n                c.conenforced AS is_enforced"
         } else {
             ""
         };
-        let has_connullsnotdistinct: bool = pg_version >= 150000
-            && sqlx::query_scalar::<_, bool>(
-                "SELECT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = 'pg_constraint'::regclass AND attname = 'connullsnotdistinct' AND NOT attisdropped)",
-            )
-            .fetch_one(pool)
-            .await
-            .unwrap_or(false);
-        let connullsnotdistinct_col = if has_connullsnotdistinct {
+        let connullsnotdistinct_col = if caps.has_connullsnotdistinct {
             ",\n                coalesce(c.connullsnotdistinct, false) AS nulls_not_distinct"
         } else {
             ""
@@ -811,6 +847,28 @@ impl Table {
             script.push_str(&format!("create table {}.{} (\n", self.schema, self.name));
 
             // 2. Add column definitions
+            // Build a map from column name (lowered) to named NOT NULL constraint.
+            // A NOT NULL constraint is "named" if its name differs from PG's
+            // auto-generated default "{table}_{col}_not_null".
+            let named_nn_constraints: HashMap<String, &TableConstraint> = self
+                .constraints
+                .iter()
+                .filter(|c| c.constraint_type.eq_ignore_ascii_case("not null"))
+                .filter_map(|c| {
+                    let def = c.definition.as_deref()?;
+                    let def_lower = def.to_lowercase();
+                    let col_name = def_lower.strip_prefix("not null ")?.trim().to_string();
+                    let raw_cname = c.name.trim_matches('"');
+                    let raw_col = col_name.trim_matches('"');
+                    let default_name = format!("{}_{}_not_null", self.raw_name, raw_col);
+                    if !raw_cname.eq_ignore_ascii_case(&default_name) {
+                        Some((col_name, c))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
             let mut column_definitions = Vec::new();
             for column in &self.columns {
                 let mut col_def = String::new();
@@ -822,7 +880,26 @@ impl Table {
                 let col_script = column.get_script();
                 // Extract just the type and constraints part (skip the quoted name)
                 if let Some(type_start) = col_script.find(' ') {
-                    col_def.push_str(&col_script[type_start + 1..]);
+                    let mut col_part = col_script[type_start + 1..].to_string();
+
+                    // If there is a named NOT NULL constraint for this column,
+                    // replace the plain "not null" with "constraint <name> not null"
+                    // (plus any modifier flags like NO INHERIT / NOT ENFORCED).
+                    if let Some(nn) = named_nn_constraints.get(&column.name.to_lowercase())
+                        && col_part.ends_with("not null")
+                    {
+                        col_part.truncate(col_part.len() - "not null".len());
+                        let mut nn_clause = format!("constraint {} not null", nn.name);
+                        if nn.no_inherit {
+                            nn_clause.push_str(" no inherit");
+                        }
+                        if !nn.is_enforced {
+                            nn_clause.push_str(" not enforced");
+                        }
+                        col_part.push_str(&nn_clause);
+                    }
+
+                    col_def.push_str(&col_part);
                 }
 
                 column_definitions.push(col_def);
@@ -944,7 +1021,7 @@ impl Table {
             }
 
             if let Some(am) = &self.access_method {
-                script.push_str(&format!("\nusing {}", am));
+                script.push_str(&format!("\nusing {}", quote_ident(am)));
             }
 
             if let Some(space) = &self.space {
@@ -954,8 +1031,9 @@ impl Table {
             script.append_block(";");
         }
 
-        // 5. Add other constraints (excluding primary key, foreign key, and NOT NULL)
-        // NOT NULL constraints are already expressed in column definitions.
+        // 5. Add other constraints (excluding primary key, foreign key, and NOT NULL).
+        // NOT NULL constraints are already expressed in column definitions
+        // (named ones with CONSTRAINT <name>, unnamed ones as plain NOT NULL).
         for constraint in &self.constraints {
             let c_type = constraint.constraint_type.to_lowercase();
             if c_type != "primary key" && c_type != "foreign key" && c_type != "not null" {
@@ -1477,7 +1555,9 @@ impl Table {
             if let Some(am) = &to_table.access_method {
                 script.append_block(&format!(
                     "alter table {}.{} set access method {};",
-                    to_table.schema, to_table.name, am
+                    to_table.schema,
+                    to_table.name,
+                    quote_ident(am)
                 ));
             } else {
                 script.append_block(&format!(
@@ -3901,6 +3981,140 @@ mod tests {
         assert!(
             script.contains("generated always as (price * qty) virtual"),
             "expected virtual generated column in table script: {script}"
+        );
+    }
+
+    // --- Named NOT NULL constraint tests (PG18 contype='n') ---
+
+    fn not_null_constraint(name: &str, column: &str) -> TableConstraint {
+        TableConstraint {
+            catalog: "postgres".to_string(),
+            schema: "public".to_string(),
+            name: name.to_string(),
+            table_name: "users".to_string(),
+            constraint_type: "NOT NULL".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some(format!("NOT NULL {column}")),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        }
+    }
+
+    #[test]
+    fn test_named_not_null_constraint_emitted_in_column_def() {
+        let table = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![identity_column("id", 1, "integer"), name_column()],
+            vec![
+                primary_key_constraint(),
+                not_null_constraint("name_must_exist", "name"),
+            ],
+            vec![primary_key_index()],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("constraint name_must_exist not null"),
+            "expected named NOT NULL constraint in column definition: {script}"
+        );
+        // Must NOT appear as a separate ALTER TABLE statement
+        assert!(
+            !script.contains("alter table public.users add constraint name_must_exist"),
+            "named NOT NULL should not be emitted as ALTER TABLE: {script}"
+        );
+    }
+
+    #[test]
+    fn test_auto_generated_not_null_name_skips_constraint_keyword() {
+        // Auto-generated name follows the pattern {table}_{col}_not_null
+        let table = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![identity_column("id", 1, "integer"), name_column()],
+            vec![
+                primary_key_constraint(),
+                not_null_constraint("users_name_not_null", "name"),
+            ],
+            vec![primary_key_index()],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        // Auto-generated name: plain "not null" without CONSTRAINT keyword
+        assert!(
+            script.contains("name text not null"),
+            "expected plain NOT NULL for auto-generated name: {script}"
+        );
+        assert!(
+            !script.contains("constraint users_name_not_null"),
+            "auto-generated NOT NULL name should not use CONSTRAINT keyword: {script}"
+        );
+    }
+
+    #[test]
+    fn test_named_not_null_with_not_enforced() {
+        let mut nn = not_null_constraint("name_nn", "name");
+        nn.is_enforced = false;
+
+        let table = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![identity_column("id", 1, "integer"), name_column()],
+            vec![primary_key_constraint(), nn],
+            vec![primary_key_index()],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("constraint name_nn not null not enforced"),
+            "expected NOT ENFORCED on named NOT NULL constraint: {script}"
+        );
+    }
+
+    #[test]
+    fn test_named_not_null_with_no_inherit() {
+        let mut nn = not_null_constraint("name_nn", "name");
+        nn.no_inherit = true;
+
+        let table = Table::new(
+            "public".to_string(),
+            "users".to_string(),
+            "public".to_string(),
+            "users".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![identity_column("id", 1, "integer"), name_column()],
+            vec![primary_key_constraint(), nn],
+            vec![primary_key_index()],
+            vec![],
+            None,
+        );
+
+        let script = table.get_script();
+        assert!(
+            script.contains("constraint name_nn not null no inherit"),
+            "expected NO INHERIT on named NOT NULL constraint: {script}"
         );
     }
 }

--- a/app/src/dump/table_column.rs
+++ b/app/src/dump/table_column.rs
@@ -49,10 +49,16 @@ pub struct TableColumn {
     pub identity_cycle: bool,                  // Whether the identity column cycles
     pub is_generated: String,                  // Whether the column is generated
     pub generation_expression: Option<String>, // Generation expression for the column
-    pub is_updatable: bool,                    // Whether the column is updatable
-    pub related_views: Option<Vec<String>>,    // Related views (optional)
+    #[serde(default)]
+    pub generation_type: Option<String>, // 's' for stored, 'v' for virtual (PG18+); None treated as stored
+    pub is_updatable: bool,                 // Whether the column is updatable
+    pub related_views: Option<Vec<String>>, // Related views (optional)
     #[serde(default)]
     pub comment: Option<String>, // Column comment
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage: Option<String>, // TOAST storage strategy (PLAIN, EXTERNAL, MAIN, EXTENDED)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compression: Option<String>, // Column compression method (pglz, lz4; PG14+)
     #[serde(skip)]
     pub serial_type: Option<String>, // Transient: set at comparison time to "serial", "bigserial", or "smallserial"
 }
@@ -279,8 +285,17 @@ impl TableColumn {
         if let Some(expr) = &self.generation_expression {
             hasher.update(expr.as_bytes());
         }
+        if let Some(gt) = &self.generation_type {
+            hasher.update(gt.as_bytes());
+        }
         if let Some(comment) = &self.comment {
             hasher.update(comment.as_bytes());
+        }
+        if let Some(storage) = &self.storage {
+            hasher.update(storage.as_bytes());
+        }
+        if let Some(compression) = &self.compression {
+            hasher.update(compression.as_bytes());
         }
         // skip catalog/charset/related_views and other descriptive-only fields
     }
@@ -395,7 +410,11 @@ impl TableColumn {
         {
             let norm_expr = Self::normalized_generation_expression(expr);
             let wrapped = format!("({norm_expr})");
-            script.push_str(&format!(" generated always as {wrapped} stored"));
+            let gen_kind = match self.generation_type.as_deref() {
+                Some("v") => "virtual",
+                _ => "stored",
+            };
+            script.push_str(&format!(" generated always as {wrapped} {gen_kind}"));
         }
 
         // Default
@@ -560,8 +579,12 @@ impl TableColumn {
                 if new_is_generated && let Some(expr) = &self.generation_expression {
                     let norm_expr = Self::normalized_generation_expression(expr);
                     let wrapped = format!("({norm_expr})");
+                    let gen_kind = match self.generation_type.as_deref() {
+                        Some("v") => "virtual",
+                        _ => "stored",
+                    };
                     let add_cmd = format!(
-                        "alter table {}.{} alter column {} add generated always as {wrapped} stored;",
+                        "alter table {}.{} alter column {} add generated always as {wrapped} {gen_kind};",
                         self.schema, self.table, self.name
                     ).with_empty_lines();
                     if use_drop || !old_is_generated {
@@ -577,6 +600,38 @@ impl TableColumn {
                         );
                     }
                 }
+            }
+        }
+
+        if self.storage != existing.storage
+            && let Some(storage) = &self.storage
+        {
+            statements.push(
+                format!(
+                    "alter table {}.{} alter column {} set storage {};",
+                    self.schema, self.table, self.name, storage
+                )
+                .with_empty_lines(),
+            );
+        }
+
+        if self.compression != existing.compression {
+            if let Some(compression) = &self.compression {
+                statements.push(
+                    format!(
+                        "alter table {}.{} alter column {} set compression {};",
+                        self.schema, self.table, self.name, compression
+                    )
+                    .with_empty_lines(),
+                );
+            } else {
+                statements.push(
+                    format!(
+                        "alter table {}.{} alter column {} set compression default;",
+                        self.schema, self.table, self.name
+                    )
+                    .with_empty_lines(),
+                );
             }
         }
 
@@ -656,7 +711,11 @@ impl TableColumn {
         {
             let norm_expr = Self::normalized_generation_expression(expr);
             let wrapped = format!("({norm_expr})");
-            statement.push_str(&format!(" generated always as {wrapped} stored"));
+            let gen_kind = match self.generation_type.as_deref() {
+                Some("v") => "virtual",
+                _ => "stored",
+            };
+            statement.push_str(&format!(" generated always as {wrapped} {gen_kind}"));
         }
 
         if let Some(default) = &self.column_default {
@@ -737,9 +796,12 @@ impl PartialEq for TableColumn {
             && self.identity_cycle == other.identity_cycle
             && self_generated == other_generated
             && (self_generated != "ALWAYS"
-                || self.generation_expression == other.generation_expression)
+                || (self.generation_expression == other.generation_expression
+                    && self.generation_type == other.generation_type))
             && self.is_updatable == other.is_updatable
             && self.comment == other.comment
+            && self.storage == other.storage
+            && self.compression == other.compression
     }
 }
 
@@ -794,9 +856,12 @@ mod tests {
             identity_cycle: false,
             is_generated: "NEVER".to_string(),
             generation_expression: None,
+            generation_type: None,
             is_updatable: true,
             related_views: None,
             comment: None,
+            storage: None,
+            compression: None,
             serial_type: None,
         }
     }
@@ -1671,5 +1736,155 @@ mod tests {
                 assert!(line.starts_with("--"), "should be commented out: {}", line);
             }
         }
+    }
+
+    // ---- PG18: generation_type (virtual generated columns) tests ----
+
+    #[test]
+    fn test_get_script_virtual_generated_column() {
+        let mut column = create_test_column();
+        column.data_type = "integer".to_string();
+        column.character_maximum_length = None;
+        column.is_generated = "ALWAYS".to_string();
+        column.generation_expression = Some("(id * 2)".to_string());
+        column.generation_type = Some("v".to_string());
+        let script = column.get_script();
+        assert_eq!(
+            script,
+            "test_column integer generated always as (id * 2) virtual"
+        );
+    }
+
+    #[test]
+    fn test_get_script_stored_generated_column_explicit() {
+        let mut column = create_test_column();
+        column.data_type = "integer".to_string();
+        column.character_maximum_length = None;
+        column.is_generated = "ALWAYS".to_string();
+        column.generation_expression = Some("(id * 2)".to_string());
+        column.generation_type = Some("s".to_string());
+        let script = column.get_script();
+        assert_eq!(
+            script,
+            "test_column integer generated always as (id * 2) stored"
+        );
+    }
+
+    #[test]
+    fn test_get_add_script_virtual_generated_column() {
+        let mut column = create_test_column();
+        column.data_type = "integer".to_string();
+        column.character_maximum_length = None;
+        column.is_generated = "ALWAYS".to_string();
+        column.generation_expression = Some("(price * qty)".to_string());
+        column.generation_type = Some("v".to_string());
+        let script = column.get_add_script();
+        assert!(
+            script.contains("generated always as (price * qty) virtual"),
+            "expected virtual in add script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_add_virtual_generated_column() {
+        let existing = create_test_column();
+        let mut updated = existing.clone();
+        updated.is_generated = "ALWAYS".to_string();
+        updated.generation_expression = Some("(id * 2)".to_string());
+        updated.generation_type = Some("v".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("expected alter statement for virtual generated column");
+
+        assert!(
+            script.contains("generated always as (id * 2) virtual"),
+            "expected virtual in alter add script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_update_virtual_generated_expression() {
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+        existing.generation_type = Some("v".to_string());
+
+        let mut updated = existing.clone();
+        updated.generation_expression = Some("(id * 3)".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("expected alter statement for virtual expression change");
+
+        assert!(
+            script.contains("drop expression"),
+            "expected drop expression: {script}"
+        );
+        assert!(
+            script.contains("generated always as (id * 3) virtual"),
+            "expected virtual in re-add: {script}"
+        );
+    }
+
+    #[test]
+    fn test_partial_eq_different_generation_type() {
+        let mut a = create_test_column();
+        a.is_generated = "ALWAYS".to_string();
+        a.generation_expression = Some("(id * 2)".to_string());
+        a.generation_type = Some("s".to_string());
+
+        let mut b = a.clone();
+        b.generation_type = Some("v".to_string());
+
+        assert_ne!(
+            a, b,
+            "columns with different generation_type should not be equal"
+        );
+    }
+
+    #[test]
+    fn test_partial_eq_generation_type_none_vs_stored() {
+        let mut a = create_test_column();
+        a.is_generated = "ALWAYS".to_string();
+        a.generation_expression = Some("(id * 2)".to_string());
+        a.generation_type = None;
+
+        let mut b = a.clone();
+        b.generation_type = Some("s".to_string());
+
+        // None != Some("s") in PartialEq (they differ structurally)
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_add_to_hasher_generation_type_affects_hash() {
+        let mut a = create_test_column();
+        a.is_generated = "ALWAYS".to_string();
+        a.generation_expression = Some("(id * 2)".to_string());
+        a.generation_type = None;
+
+        let mut b = a.clone();
+        b.generation_type = Some("v".to_string());
+
+        let mut ha = Sha256::new();
+        let mut hb = Sha256::new();
+        a.add_to_hasher(&mut ha);
+        b.add_to_hasher(&mut hb);
+        assert_ne!(
+            format!("{:x}", ha.finalize()),
+            format!("{:x}", hb.finalize()),
+            "generation_type should affect the hash"
+        );
+    }
+
+    #[test]
+    fn test_serde_default_generation_type() {
+        let json = r#"{"catalog":"c","schema":"s","table":"t","name":"n","ordinal_position":1,"is_nullable":true,"data_type":"int","is_self_referencing":false,"is_identity":false,"identity_cycle":false,"is_generated":"NEVER","is_updatable":true}"#;
+        let c: TableColumn = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            c.generation_type, None,
+            "missing generation_type should default to None"
+        );
     }
 }

--- a/app/src/dump/table_column.rs
+++ b/app/src/dump/table_column.rs
@@ -131,6 +131,16 @@ impl TableColumn {
         }
     }
 
+    /// Returns the effective generation type: `"s"` (stored) or `"v"` (virtual).
+    /// Treats `None` as `"s"` so that older dumps missing the field compare
+    /// equal to newer dumps that explicitly record `Some("s")`.
+    fn effective_generation_type(&self) -> &str {
+        match self.generation_type.as_deref() {
+            Some("v") => "v",
+            _ => "s",
+        }
+    }
+
     fn normalized_generation_expression(expr: &str) -> String {
         let mut trimmed = expr.trim();
         // Strip redundant outer parentheses to avoid emitted ((expr)) which some servers reject
@@ -285,9 +295,7 @@ impl TableColumn {
         if let Some(expr) = &self.generation_expression {
             hasher.update(expr.as_bytes());
         }
-        if let Some(gt) = &self.generation_type {
-            hasher.update(gt.as_bytes());
-        }
+        hasher.update(self.effective_generation_type().as_bytes());
         if let Some(comment) = &self.comment {
             hasher.update(comment.as_bytes());
         }
@@ -797,7 +805,7 @@ impl PartialEq for TableColumn {
             && self_generated == other_generated
             && (self_generated != "ALWAYS"
                 || (self.generation_expression == other.generation_expression
-                    && self.generation_type == other.generation_type))
+                    && self.effective_generation_type() == other.effective_generation_type()))
             && self.is_updatable == other.is_updatable
             && self.comment == other.comment
             && self.storage == other.storage
@@ -1364,7 +1372,7 @@ mod tests {
         // This is a known hash for the test data - if the hashing logic changes, this will fail
         assert_eq!(
             hash_hex,
-            "e8f4ac1ac6ef0cb7edf47a8fe070ccf7b80c70e4ba37937f80e06cb663ee65e2"
+            "e71094fafb6a1f2d03c80ba04c8fea5dac0269f681cbe1c0e4afb1a8482b0db2"
         );
     }
 
@@ -1853,8 +1861,8 @@ mod tests {
         let mut b = a.clone();
         b.generation_type = Some("s".to_string());
 
-        // None != Some("s") in PartialEq (they differ structurally)
-        assert_ne!(a, b);
+        // None is treated as stored ("s"), so they are semantically equal
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -15,7 +15,7 @@ pub struct TableConstraint {
     pub initially_deferred: bool, // Whether the constraint is initially deferred
     pub definition: Option<String>, // Definition of the constraint (e.g., check expression)
     #[serde(default)]
-    pub coninhcount: i16, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
+    pub coninhcount: i32, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
 }
 
 impl TableConstraint {
@@ -1297,6 +1297,102 @@ mod tests {
         assert_eq!(
             norm,
             "check (x::character varying = ']::text[]' and y::character varying = 'ok')"
+        );
+    }
+
+    // --- coninhcount i32 compatibility (PG14 INT4 / PG16+ INT2) ---
+
+    #[test]
+    fn test_coninhcount_accepts_i16_range_values() {
+        // PG16+ returns INT2 values, which fit in i32
+        let constraint = TableConstraint {
+            catalog: "db".to_string(),
+            schema: "public".to_string(),
+            name: "pk_test".to_string(),
+            table_name: "test".to_string(),
+            constraint_type: "PRIMARY KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: None,
+            coninhcount: 0,
+        };
+        assert_eq!(constraint.coninhcount, 0);
+
+        let mut inherited = constraint.clone();
+        inherited.coninhcount = i16::MAX as i32;
+        assert_eq!(inherited.coninhcount, 32767);
+    }
+
+    #[test]
+    fn test_coninhcount_accepts_i32_range_values() {
+        // PG14 returns INT4 values, which require i32
+        let mut constraint = create_primary_key_constraint();
+        constraint.coninhcount = i32::MAX;
+        assert_eq!(constraint.coninhcount, i32::MAX);
+
+        constraint.coninhcount = 100_000; // exceeds i16::MAX
+        assert_eq!(constraint.coninhcount, 100_000);
+    }
+
+    #[test]
+    fn test_coninhcount_serde_roundtrip_zero() {
+        let constraint = create_primary_key_constraint();
+        let json = serde_json::to_string(&constraint).unwrap();
+        let deserialized: TableConstraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.coninhcount, 0);
+    }
+
+    #[test]
+    fn test_coninhcount_serde_roundtrip_large_value() {
+        let mut constraint = create_primary_key_constraint();
+        constraint.coninhcount = 100_000;
+        let json = serde_json::to_string(&constraint).unwrap();
+        let deserialized: TableConstraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.coninhcount, 100_000);
+    }
+
+    #[test]
+    fn test_coninhcount_serde_default_when_missing() {
+        // Older dumps may not include the field; #[serde(default)] should yield 0
+        let json = r#"{
+            "catalog": "db",
+            "schema": "public",
+            "name": "pk",
+            "table_name": "t",
+            "constraint_type": "PRIMARY KEY",
+            "is_deferrable": false,
+            "initially_deferred": false,
+            "definition": null
+        }"#;
+        let deserialized: TableConstraint = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.coninhcount, 0);
+    }
+
+    #[test]
+    fn test_coninhcount_not_included_in_equality() {
+        // coninhcount is intentionally excluded from PartialEq
+        let mut a = create_primary_key_constraint();
+        let mut b = create_primary_key_constraint();
+        a.coninhcount = 0;
+        b.coninhcount = 5;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_coninhcount_not_included_in_hash() {
+        // coninhcount is intentionally excluded from the SHA256 hash
+        let mut a = create_primary_key_constraint();
+        let mut b = create_primary_key_constraint();
+        a.coninhcount = 0;
+        b.coninhcount = 42;
+
+        let mut ha = Sha256::new();
+        let mut hb = Sha256::new();
+        a.add_to_hasher(&mut ha);
+        b.add_to_hasher(&mut hb);
+        assert_eq!(
+            format!("{:x}", ha.finalize()),
+            format!("{:x}", hb.finalize()),
         );
     }
 }

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -16,9 +16,20 @@ pub struct TableConstraint {
     pub definition: Option<String>, // Definition of the constraint (e.g., check expression)
     #[serde(default)]
     pub coninhcount: i32, // Number of direct inheritance ancestors (0 = local, >0 = inherited)
+    #[serde(default = "TableConstraint::default_enforced")]
+    pub is_enforced: bool, // Whether the constraint is enforced (PG18+ supports NOT ENFORCED)
+    #[serde(default)]
+    pub no_inherit: bool, // Whether the constraint is marked NO INHERIT
+    #[serde(default)]
+    pub nulls_not_distinct: bool, // PG15+: UNIQUE constraint treats NULLs as not distinct
 }
 
 impl TableConstraint {
+    /// Default value for is_enforced (backward compat with old dumps)
+    fn default_enforced() -> bool {
+        true
+    }
+
     /// Hash
     pub fn add_to_hasher(&self, hasher: &mut Sha256) {
         hasher.update(self.schema.as_bytes());
@@ -27,6 +38,9 @@ impl TableConstraint {
         hasher.update(self.constraint_type.as_bytes());
         hasher.update(self.is_deferrable.to_string().as_bytes());
         hasher.update(self.initially_deferred.to_string().as_bytes());
+        hasher.update(self.is_enforced.to_string().as_bytes());
+        hasher.update(self.no_inherit.to_string().as_bytes());
+        hasher.update(self.nulls_not_distinct.to_string().as_bytes());
         if let Some(definition) = &self.definition {
             hasher.update(Self::normalize_definition(definition).as_bytes());
         }
@@ -74,12 +88,21 @@ impl TableConstraint {
                 }
                 "UNIQUE" => parts.push("unique".to_string()),
                 "CHECK" => parts.push("check".to_string()),
+                "EXCLUDE" => parts.push("exclude".to_string()),
+                "NOT NULL" => parts.push("not null".to_string()),
                 _ => {}
             }
             parts.join(" ")
         };
 
         script.push_str(&format!("{} ", clause));
+        if !self.is_enforced {
+            // Remove trailing space before appending NOT ENFORCED
+            let trimmed = script.trim_end().to_string();
+            script.clear();
+            script.push_str(&trimmed);
+            script.push_str(" not enforced ");
+        }
         script.append_block(";");
         script
     }
@@ -197,7 +220,8 @@ impl TableConstraint {
     /// Get alter script to change this constraint to match the target constraint
     /// Returns None if the constraint needs to be dropped and recreated
     pub fn get_alter_script(&self, target: &TableConstraint) -> Option<String> {
-        // Only FOREIGN KEY constraints can have their deferrable properties altered
+        // FOREIGN KEY constraints can have their deferrable and enforced properties altered
+        // CHECK constraints can have their enforced property altered (PG18+)
         // All other changes require drop/recreate
         if self.constraint_type.eq_ignore_ascii_case("FOREIGN KEY")
             && target.constraint_type.eq_ignore_ascii_case("FOREIGN KEY")
@@ -229,6 +253,70 @@ impl TableConstraint {
                 }
             }
 
+            // Handle enforced property changes (PG18+)
+            if self.is_enforced != target.is_enforced {
+                if target.is_enforced {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} enforced;",
+                        self.schema, self.table_name, target.name
+                    ));
+                } else {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} not enforced;",
+                        self.schema, self.table_name, target.name
+                    ));
+                }
+            }
+
+            // Handle no_inherit property changes (PG18+)
+            if self.no_inherit != target.no_inherit {
+                if target.no_inherit {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} no inherit;",
+                        self.schema, self.table_name, target.name
+                    ));
+                } else {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} inherit;",
+                        self.schema, self.table_name, target.name
+                    ));
+                }
+            }
+
+            Some(script)
+        } else if (self.constraint_type.eq_ignore_ascii_case("CHECK")
+            || self.constraint_type.eq_ignore_ascii_case("FOREIGN KEY"))
+            && self.can_be_altered_to(target)
+            && (self.is_enforced != target.is_enforced || self.no_inherit != target.no_inherit)
+        {
+            // CHECK/FK constraint enforced or no_inherit property change (PG18+)
+            let mut script = String::new();
+            if self.is_enforced != target.is_enforced {
+                if target.is_enforced {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} enforced;",
+                        self.schema, self.table_name, target.name
+                    ));
+                } else {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} not enforced;",
+                        self.schema, self.table_name, target.name
+                    ));
+                }
+            }
+            if self.no_inherit != target.no_inherit {
+                if target.no_inherit {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} no inherit;",
+                        self.schema, self.table_name, target.name
+                    ));
+                } else {
+                    script.append_block(&format!(
+                        "alter table {}.{} alter constraint {} inherit;",
+                        self.schema, self.table_name, target.name
+                    ));
+                }
+            }
             Some(script)
         } else {
             None
@@ -238,20 +326,37 @@ impl TableConstraint {
     /// Check if this constraint can be altered to match the target constraint
     /// without dropping and recreating
     pub fn can_be_altered_to(&self, target: &TableConstraint) -> bool {
-        // Only FOREIGN KEY constraints can have their deferrable properties altered
+        // FOREIGN KEY constraints can have deferrable and enforced properties altered
+        // CHECK constraints can have enforced property altered (PG18+)
         // All other changes require drop/recreate
         if self.constraint_type.eq_ignore_ascii_case("FOREIGN KEY")
             && target.constraint_type.eq_ignore_ascii_case("FOREIGN KEY")
         {
-            // Check if only deferrable properties changed
+            // Check if only deferrable/enforced properties changed
             self.catalog == target.catalog
                 && self.schema == target.schema
                 && self.name == target.name
                 && self.table_name == target.table_name
                 && self.constraint_type == target.constraint_type
+                && self.nulls_not_distinct == target.nulls_not_distinct
                 && self.definition.as_deref().map(Self::normalize_definition)
                     == target.definition.as_deref().map(Self::normalize_definition)
-            // Only is_deferrable and initially_deferred can differ
+            // is_deferrable, initially_deferred, is_enforced, and no_inherit can differ
+        } else if self.constraint_type.eq_ignore_ascii_case("CHECK")
+            && target.constraint_type.eq_ignore_ascii_case("CHECK")
+        {
+            // CHECK constraints: enforced and no_inherit can be altered (PG18+)
+            self.catalog == target.catalog
+                && self.schema == target.schema
+                && self.name == target.name
+                && self.table_name == target.table_name
+                && self.constraint_type == target.constraint_type
+                && self.is_deferrable == target.is_deferrable
+                && self.initially_deferred == target.initially_deferred
+                && self.nulls_not_distinct == target.nulls_not_distinct
+                && self.definition.as_deref().map(Self::normalize_definition)
+                    == target.definition.as_deref().map(Self::normalize_definition)
+            // is_enforced and no_inherit can differ
         } else {
             false
         }
@@ -275,6 +380,9 @@ impl PartialEq for TableConstraint {
             && self.constraint_type == other.constraint_type
             && self.is_deferrable == other.is_deferrable
             && self.initially_deferred == other.initially_deferred
+            && self.is_enforced == other.is_enforced
+            && self.no_inherit == other.no_inherit
+            && self.nulls_not_distinct == other.nulls_not_distinct
             && self.definition.as_deref().map(Self::normalize_definition)
                 == other.definition.as_deref().map(Self::normalize_definition)
     }
@@ -296,6 +404,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -310,6 +421,9 @@ mod tests {
             initially_deferred: true,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -324,6 +438,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -338,6 +455,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         }
     }
 
@@ -546,6 +666,9 @@ mod tests {
             initially_deferred: true,
             definition: Some("UNIQUE (id)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         let script = constraint.get_script();
@@ -565,6 +688,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("PRIMARY KEY (id)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         let script = constraint.get_script();
@@ -584,6 +710,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         let script = constraint.get_script();
@@ -722,6 +851,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("UNIQUE (column1, column2)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         // Should handle special characters in all fields
@@ -750,6 +882,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("PRIMARY KEY (id)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             },
             TableConstraint {
                 catalog: "db".to_string(),
@@ -761,6 +896,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("FOREIGN KEY (user_id) REFERENCES users(id)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             },
             TableConstraint {
                 catalog: "db".to_string(),
@@ -772,6 +910,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("UNIQUE (column1, column2)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             },
             TableConstraint {
                 catalog: "db".to_string(),
@@ -783,6 +924,9 @@ mod tests {
                 initially_deferred: false,
                 definition: Some("CHECK (age > 0)".to_string()),
                 coninhcount: 0,
+                is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             },
         ];
 
@@ -813,6 +957,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         // Create the same hash as the implementation
@@ -823,6 +970,9 @@ mod tests {
         hasher.update("PK".as_bytes()); // constraint_type
         hasher.update("false".as_bytes()); // is_deferrable
         hasher.update("false".as_bytes()); // initially_deferred
+        hasher.update("true".as_bytes()); // is_enforced
+        hasher.update("false".as_bytes()); // no_inherit
+        hasher.update("false".as_bytes()); // nulls_not_distinct
 
         let expected_hash = format!("{:x}", hasher.finalize());
 
@@ -845,6 +995,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
 
         // Create the same hash as the implementation (nulls_distinct=None means no update)
@@ -855,6 +1008,9 @@ mod tests {
         hasher.update("PK".as_bytes()); // constraint_type
         hasher.update("false".as_bytes()); // is_deferrable
         hasher.update("false".as_bytes()); // initially_deferred
+        hasher.update("true".as_bytes()); // is_enforced
+        hasher.update("false".as_bytes()); // no_inherit
+        hasher.update("false".as_bytes()); // nulls_not_distinct
         // No nulls_distinct update for None
 
         let expected_hash = format!("{:x}", hasher.finalize());
@@ -985,6 +1141,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (status = 'Active')".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let script = constraint.get_script();
         assert!(
@@ -1007,6 +1166,9 @@ mod tests {
                 "CHECK (status IN ('Active', 'Inactive', 'PendingReview'))".to_string(),
             ),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let script = constraint.get_script();
         assert!(script.contains("'Active'"), "got: {script}");
@@ -1029,6 +1191,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (col <> 'It''s OK')".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let script = constraint.get_script();
         assert!(
@@ -1049,6 +1214,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (AGE > 0 AND NAME IS NOT NULL)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let script = constraint.get_script();
         assert!(
@@ -1071,6 +1239,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (AMOUNT >= 0)".to_string()),
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         let script = constraint.get_script();
         assert!(script.contains("check (amount >= 0)"), "got: {script}");
@@ -1183,6 +1354,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (priority::text = ANY (ARRAY['P1'::character varying, 'P2'::character varying]::text[]))".to_string()),
         coninhcount: 0,
+            is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             };
         let constraint_b = TableConstraint {
             catalog: "db".to_string(),
@@ -1194,6 +1368,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (priority::text = ANY (ARRAY['P1'::character varying::text, 'P2'::character varying::text]))".to_string()),
         coninhcount: 0,
+            is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             };
         assert_eq!(constraint_a, constraint_b);
     }
@@ -1210,6 +1387,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (priority::text = ANY (ARRAY['P1'::character varying, 'P2'::character varying]::text[]))".to_string()),
         coninhcount: 0,
+            is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             };
         let constraint_b = TableConstraint {
             catalog: "db".to_string(),
@@ -1221,6 +1401,9 @@ mod tests {
             initially_deferred: false,
             definition: Some("CHECK (priority::text = ANY (ARRAY['P1'::character varying::text, 'P2'::character varying::text]))".to_string()),
         coninhcount: 0,
+            is_enforced: true,
+                no_inherit: false,
+                nulls_not_distinct: false,
             };
 
         let mut hasher_a = Sha256::new();
@@ -1315,6 +1498,9 @@ mod tests {
             initially_deferred: false,
             definition: None,
             coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
         };
         assert_eq!(constraint.coninhcount, 0);
 
@@ -1394,5 +1580,315 @@ mod tests {
             format!("{:x}", ha.finalize()),
             format!("{:x}", hb.finalize()),
         );
+    }
+
+    // ---- PG18: is_enforced tests ----
+
+    #[test]
+    fn test_get_script_not_enforced_check() {
+        let constraint = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "chk_status".to_string(),
+            table_name: "orders".to_string(),
+            constraint_type: "CHECK".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("CHECK (status <> '')".to_string()),
+            coninhcount: 0,
+            is_enforced: false,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let script = constraint.get_script();
+        assert!(
+            script.contains("not enforced"),
+            "expected 'not enforced' in script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_script_not_enforced_foreign_key() {
+        let constraint = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "fk_order_user".to_string(),
+            table_name: "orders".to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("FOREIGN KEY (user_id) REFERENCES public.users(id)".to_string()),
+            coninhcount: 0,
+            is_enforced: false,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let script = constraint.get_script();
+        assert!(
+            script.contains("not enforced"),
+            "expected 'not enforced' in FK script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_script_enforced_omits_keyword() {
+        let constraint = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "chk_positive".to_string(),
+            table_name: "items".to_string(),
+            constraint_type: "CHECK".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("CHECK (qty > 0)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let script = constraint.get_script();
+        assert!(
+            !script.contains("not enforced") && !script.contains("enforced"),
+            "enforced=true should not emit any enforced keyword: {script}"
+        );
+    }
+
+    #[test]
+    fn test_partial_eq_different_is_enforced() {
+        let mut a = create_check_constraint();
+        a.is_enforced = true;
+        let mut b = a.clone();
+        b.is_enforced = false;
+        assert_ne!(
+            a, b,
+            "constraints with different is_enforced should not be equal"
+        );
+    }
+
+    #[test]
+    fn test_add_to_hasher_is_enforced_affects_hash() {
+        let mut a = create_check_constraint();
+        a.is_enforced = true;
+        let mut b = a.clone();
+        b.is_enforced = false;
+
+        let mut ha = Sha256::new();
+        let mut hb = Sha256::new();
+        a.add_to_hasher(&mut ha);
+        b.add_to_hasher(&mut hb);
+        assert_ne!(
+            format!("{:x}", ha.finalize()),
+            format!("{:x}", hb.finalize()),
+            "is_enforced should affect the hash"
+        );
+    }
+
+    #[test]
+    fn test_can_be_altered_to_check_enforced_change() {
+        let a = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "chk_val".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "CHECK".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("CHECK (val > 0)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut b = a.clone();
+        b.is_enforced = false;
+        assert!(
+            a.can_be_altered_to(&b),
+            "CHECK constraint should be alterable when only is_enforced differs"
+        );
+    }
+
+    #[test]
+    fn test_can_be_altered_to_fk_enforced_change() {
+        let a = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "fk_ref".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("FOREIGN KEY (x) REFERENCES public.y(id)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut b = a.clone();
+        b.is_enforced = false;
+        assert!(
+            a.can_be_altered_to(&b),
+            "FK constraint should be alterable when only is_enforced differs"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_fk_enforced_to_not_enforced() {
+        let old = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "fk_ref".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("FOREIGN KEY (x) REFERENCES public.y(id)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut new_c = old.clone();
+        new_c.is_enforced = false;
+
+        let script = old
+            .get_alter_script(&new_c)
+            .expect("should produce alter script");
+        assert!(
+            script.contains("alter table public.t alter constraint fk_ref not enforced"),
+            "expected NOT ENFORCED alter: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_fk_not_enforced_to_enforced() {
+        let old = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "fk_ref".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("FOREIGN KEY (x) REFERENCES public.y(id)".to_string()),
+            coninhcount: 0,
+            is_enforced: false,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut new_c = old.clone();
+        new_c.is_enforced = true;
+
+        let script = old
+            .get_alter_script(&new_c)
+            .expect("should produce alter script");
+        assert!(
+            script.contains("alter table public.t alter constraint fk_ref enforced"),
+            "expected ENFORCED alter: {script}"
+        );
+        assert!(
+            !script.contains("not enforced"),
+            "should not contain 'not enforced': {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_check_enforced_change() {
+        let old = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "chk_val".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "CHECK".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("CHECK (val > 0)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut new_c = old.clone();
+        new_c.is_enforced = false;
+
+        let script = old
+            .get_alter_script(&new_c)
+            .expect("should produce alter script");
+        assert!(
+            script.contains("alter table public.t alter constraint chk_val not enforced"),
+            "expected NOT ENFORCED for CHECK alter: {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_check_not_enforced_to_enforced() {
+        let old = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "chk_val".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "CHECK".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("CHECK (val > 0)".to_string()),
+            coninhcount: 0,
+            is_enforced: false,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut new_c = old.clone();
+        new_c.is_enforced = true;
+
+        let script = old
+            .get_alter_script(&new_c)
+            .expect("should produce alter script");
+        assert!(
+            script.contains("alter table public.t alter constraint chk_val enforced"),
+            "expected ENFORCED for CHECK alter: {script}"
+        );
+        assert!(
+            !script.contains("not enforced"),
+            "should not contain 'not enforced': {script}"
+        );
+    }
+
+    #[test]
+    fn test_get_alter_script_fk_deferrable_and_enforced_change() {
+        let old = TableConstraint {
+            catalog: "test".to_string(),
+            schema: "public".to_string(),
+            name: "fk_ref".to_string(),
+            table_name: "t".to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some("FOREIGN KEY (x) REFERENCES public.y(id)".to_string()),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+        };
+        let mut new_c = old.clone();
+        new_c.is_deferrable = true;
+        new_c.initially_deferred = true;
+        new_c.is_enforced = false;
+
+        let script = old
+            .get_alter_script(&new_c)
+            .expect("should produce alter script");
+        assert!(
+            script.contains("deferrable initially deferred"),
+            "expected deferrable change: {script}"
+        );
+        assert!(
+            script.contains("not enforced"),
+            "expected enforced change: {script}"
+        );
+    }
+
+    #[test]
+    fn test_serde_default_enforced() {
+        let json = r#"{"catalog":"db","schema":"s","name":"c","table_name":"t","constraint_type":"CHECK","is_deferrable":false,"initially_deferred":false,"definition":null}"#;
+        let c: TableConstraint = serde_json::from_str(json).unwrap();
+        assert!(c.is_enforced, "missing is_enforced should default to true");
     }
 }

--- a/app/src/dump/view.rs
+++ b/app/src/dump/view.rs
@@ -28,6 +28,9 @@ pub struct View {
     /// ACL (grant) entries for this view
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub acl: Vec<String>,
+    /// Whether this view uses SECURITY INVOKER (PG15+)
+    #[serde(default)]
+    pub security_invoker: bool,
 }
 
 impl View {
@@ -48,6 +51,7 @@ impl View {
             is_materialized: false,
             hash: None,
             acl: Vec::new(),
+            security_invoker: false,
         };
         view.hash();
         view
@@ -67,13 +71,14 @@ impl View {
         self.hash = Some(format!(
             "{:x}",
             md5::compute(format!(
-                "{}.{}.{}.{}.{}.{}",
+                "{}.{}.{}.{}.{}.{}.{}",
                 self.schema,
                 self.name,
                 self.definition,
                 self.owner,
                 self.comment.clone().unwrap_or_default(),
-                self.is_materialized
+                self.is_materialized,
+                self.security_invoker
             ))
         ));
     }
@@ -81,11 +86,17 @@ impl View {
     /// Returns a string to create the view.
     pub fn get_script(&self) -> String {
         let keyword = self.view_keyword();
+        let with_clause = if self.security_invoker {
+            " with (security_invoker = true)"
+        } else {
+            ""
+        };
         let script = format!(
-            "create {} {}.{} as\n{}",
+            "create {} {}.{}{} as\n{}",
             keyword,
             self.schema,
             self.name,
+            with_clause,
             self.definition.trim_end()
         )
         .with_empty_lines();
@@ -148,6 +159,7 @@ impl View {
 
         if current_definition == desired_definition
             && self.is_materialized == target.is_materialized
+            && self.security_invoker == target.security_invoker
         {
             return format!(
                 "-- View {}.{} requires no changes.\n",
@@ -183,18 +195,48 @@ impl View {
             }
         }
 
-        let script = target.get_script();
-        if script.to_uppercase().contains("CREATE OR REPLACE VIEW") {
-            return script;
+        let mut script = if current_definition != desired_definition {
+            let s = target.get_script();
+            if s.to_uppercase().contains("CREATE OR REPLACE VIEW") {
+                s
+            } else {
+                let with_clause = if target.security_invoker {
+                    " with (security_invoker = true)"
+                } else {
+                    ""
+                };
+                format!(
+                    "CREATE OR REPLACE VIEW {}.{}{} AS\n{}",
+                    target.schema,
+                    target.name,
+                    with_clause,
+                    target.definition.trim_end()
+                )
+                .with_empty_lines()
+            }
+        } else {
+            String::new()
+        };
+
+        // Handle security_invoker changes (only for regular views; materialized
+        // views are handled by drop+recreate above)
+        if self.security_invoker != target.security_invoker
+            && current_definition == desired_definition
+        {
+            if target.security_invoker {
+                script.append_block(&format!(
+                    "alter view {}.{} set (security_invoker = true);",
+                    target.schema, target.name
+                ));
+            } else {
+                script.append_block(&format!(
+                    "alter view {}.{} reset (security_invoker);",
+                    target.schema, target.name
+                ));
+            }
         }
 
-        format!(
-            "CREATE OR REPLACE VIEW {}.{} AS\n{}",
-            target.schema,
-            target.name,
-            target.definition.trim_end()
-        )
-        .with_empty_lines()
+        script
     }
 }
 
@@ -230,7 +272,7 @@ mod tests {
 
         let expected_hash = format!(
             "{:x}",
-            md5::compute(format!("analytics.active_users.{definition}...false"))
+            md5::compute(format!("analytics.active_users.{definition}...false.false"))
         );
 
         assert_eq!(view.hash.as_deref(), Some(expected_hash.as_str()));

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -20,7 +20,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 ### 2. Extensions
 - **Added**: `hstore` extension in Schema B
 - **Removed**: `pgcrypto` extension in Schema B
-- **Unchanged**: `uuid-ossp`, `pg_trgm`
+- **Unchanged**: `uuid-ossp`, `pg_trgm`, `btree_gist`, `postgres_fdw`
 
 ### 3. Custom Types
 
@@ -226,7 +226,47 @@ Grant comparison test using roles `pgc_grant_reader` and `pgc_grant_writer`.
 - `USAGE` on `test_schema.user_id_seq` (sequence) → `pgc_grant_reader` (no grant in TO)
 - `EXECUTE` on `test_schema.update_timestamp()` (function) → `pgc_grant_reader` (no grant in TO)
 
-### 18. Special Test Scenarios
+### 18. Exclusion Constraints (btree_gist)
+- **Extension**: `btree_gist` added in both schemas
+- **Modified**: `test_schema.reservations` — exclusion constraint unchanged, but table gains `guest_name` column in Schema B
+- **Removed**: `test_schema.shift_schedule` — FROM-only table with exclusion constraint
+- **Added**: `test_schema.booking_slots` — TO-only table with exclusion constraint
+
+### 19. NULLS NOT DISTINCT (PG15+)
+- **Modified**: `test_schema.unique_nulls_test` — unique constraint `uq_unique_nulls_code` changes from standard UNIQUE (allows multiple NULLs) to `UNIQUE NULLS NOT DISTINCT` (single NULL) in Schema B
+
+### 20. NO INHERIT Constraint Flag
+- **Modified**: `test_schema.categories` constraint `chk_categories_sort_order` — regular CHECK in FROM, `CHECK ... NO INHERIT` in TO
+
+### 21. Column STORAGE and COMPRESSION (PG14+)
+- **Modified**: `test_schema.storage_test` — columns `payload` and `blob` have default STORAGE in FROM; TO sets STORAGE to EXTERNAL on both. Compression (`lz4`) is commented out but can be enabled on PG14+ compiled with `--with-lz4`
+
+### 22. SECURITY INVOKER Views (PG15+)
+- **Modified**: `test_schema.security_invoker_view` — same query in both schemas; TO adds `WITH (security_invoker = true)` option
+
+### 23. Range Types
+- **Modified**: `test_schema.float_range` — FROM has `SUBTYPE_DIFF = float8mi`; TO removes it (triggers drop+recreate since ranges cannot be altered in-place)
+- **Removed**: `test_schema.old_range` — FROM-only range type
+- **Added**: `test_schema.int_range` — TO-only range type
+
+### 24. Foreign Tables (postgres_fdw)
+- **Extensions**: `postgres_fdw` added in both schemas; `test_foreign_server` created in both schemas
+- **Modified**: `test_schema.foreign_users` — `username` VARCHAR(50) → VARCHAR(100); added `status` column in TO
+- **Removed**: `test_schema.foreign_logs` — FROM-only foreign table
+- **Added**: `test_schema.foreign_products` — TO-only foreign table
+
+### 25. Extended Statistics (PG10+)
+- **Modified**: `test_schema.stat_users_email_status` — FROM has `(dependencies, ndistinct)`; TO adds `mcv` kind (triggers drop+recreate)
+- **Removed**: `test_schema.stat_products_old` — FROM-only statistics
+- **Added**: `test_schema.stat_products_new` — TO-only statistics on products table
+
+### 26. NOT ENFORCED Constraints (PG18+)
+- **Modified**: `test_schema.products` constraint `chk_products_sku_format` — enforced CHECK in FROM; `NOT ENFORCED` in TO. Requires PostgreSQL 18+
+
+### 27. Virtual Generated Columns (PG18+)
+- **Modified**: `test_schema.virtual_gen_test` — column `full_name` is a plain NOT NULL column in FROM; becomes `GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED` in TO. On PG18+ this can test VIRTUAL generation; on earlier versions, STORED is used
+
+### 28. Special Test Scenarios
 
 #### CHECK Constraint String Literal Case Preservation
 - `chk_category_values` contains mixed-case string literals (`'Electronics'`, `'Home & Garden'`, `'Books'`) identical in both schemas
@@ -408,3 +448,13 @@ The comparison should detect and generate SQL for:
 - Not emitting extension-owned objects as individual creates/drops
 - Using serial/bigserial types instead of separate sequences where appropriate
 - Stripping SQL comments from output when `--use-comments false` is specified (preserving comments inside function bodies)
+- Handling exclusion constraints (create, drop, alter via table changes)
+- Detecting NULLS NOT DISTINCT changes on unique constraints (PG15+)
+- Detecting NO INHERIT flag changes on CHECK constraints
+- Detecting column STORAGE and COMPRESSION changes (PG14+)
+- Handling SECURITY INVOKER view option changes (PG15+)
+- Handling range type changes via drop+recreate (ranges cannot be altered in-place)
+- Creating, dropping, and altering foreign tables (column add/drop/alter, server changes, options)
+- Creating, dropping, and altering extended statistics (kind changes via drop+recreate)
+- Detecting NOT ENFORCED constraint flag changes (PG18+)
+- Handling virtual/stored generated column transitions (PG18+)

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -899,6 +899,149 @@ ALTER MATERIALIZED VIEW test_schema.active_users_mat OWNER TO pgc_owner_from;
 --   3. Correctly handle identity columns (skip sequence as well)
 
 -- =============================================================================
+-- PG14–18 feature test: Exclusion constraints (btree_gist)
+-- =============================================================================
+-- Tests exclusion constraint detection and comparison.
+-- FROM: table with exclusion constraint.
+-- TO: table modified (new column added), exclusion constraint unchanged.
+-- Also: FROM has a second exclusion constraint table that is removed in TO.
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
+
+CREATE TABLE test_schema.reservations (
+    id SERIAL PRIMARY KEY,
+    room_id INTEGER NOT NULL,
+    during TSTZRANGE NOT NULL,
+    EXCLUDE USING gist (room_id WITH =, during WITH &&)
+);
+
+-- Exclusion constraint table only in FROM (should be dropped in TO)
+CREATE TABLE test_schema.shift_schedule (
+    id SERIAL PRIMARY KEY,
+    employee_id INTEGER NOT NULL,
+    shift TSTZRANGE NOT NULL,
+    EXCLUDE USING gist (employee_id WITH =, shift WITH &&)
+);
+
+-- =============================================================================
+-- PG14–18 feature test: NULLS NOT DISTINCT (PG15+)
+-- =============================================================================
+-- FROM: standard UNIQUE constraint (allows multiple NULLs).
+-- TO: UNIQUE NULLS NOT DISTINCT (only one NULL allowed).
+CREATE TABLE test_schema.unique_nulls_test (
+    id SERIAL PRIMARY KEY,
+    code VARCHAR(50),
+    CONSTRAINT uq_unique_nulls_code UNIQUE (code)
+);
+
+-- =============================================================================
+-- PG14–18 feature test: NO INHERIT constraint flag
+-- =============================================================================
+-- FROM: CHECK constraint without NO INHERIT.
+-- TO: same CHECK constraint with NO INHERIT flag added.
+ALTER TABLE test_schema.categories ADD CONSTRAINT chk_categories_sort_order
+    CHECK (sort_order >= 0);
+
+-- =============================================================================
+-- PG14–18 feature test: Column STORAGE and COMPRESSION (PG14+)
+-- =============================================================================
+-- FROM: table with default STORAGE on text column, no explicit compression.
+-- TO: STORAGE changed to EXTERNAL, compression set to lz4 (PG14+).
+CREATE TABLE test_schema.storage_test (
+    id SERIAL PRIMARY KEY,
+    payload TEXT,
+    blob BYTEA
+);
+
+-- =============================================================================
+-- PG14–18 feature test: SECURITY INVOKER views (PG15+)
+-- =============================================================================
+-- FROM: simple view without security_invoker.
+-- TO: same view definition but WITH (security_invoker = true).
+CREATE VIEW test_schema.security_invoker_view AS
+SELECT id, username, email
+FROM test_schema.users
+WHERE status = 'active';
+
+-- =============================================================================
+-- PG14–18 feature test: Range types
+-- =============================================================================
+-- FROM: range type with subtype_diff.
+-- TO: range type without subtype_diff (triggers drop+recreate).
+-- Also: FROM has an old_range type that is removed in TO.
+-- Also: TO has a new int_range type that is created.
+CREATE TYPE test_schema.float_range AS RANGE (
+    SUBTYPE = float8,
+    SUBTYPE_DIFF = float8mi
+);
+
+CREATE TYPE test_schema.old_range AS RANGE (
+    SUBTYPE = int4
+);
+
+-- =============================================================================
+-- PG14–18 feature test: Foreign tables (postgres_fdw)
+-- =============================================================================
+-- Tests foreign table creation, modification, and removal.
+-- Requires postgres_fdw extension and a foreign server.
+CREATE EXTENSION IF NOT EXISTS postgres_fdw WITH SCHEMA public;
+
+CREATE SERVER test_foreign_server
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (host 'localhost', dbname 'postgres');
+
+-- FROM: foreign table with basic columns and options.
+-- TO: modified (column type change, new column, changed table options).
+CREATE FOREIGN TABLE test_schema.foreign_users (
+    id INTEGER NOT NULL,
+    username VARCHAR(50),
+    email VARCHAR(255)
+) SERVER test_foreign_server
+OPTIONS (schema_name 'public', table_name 'users');
+
+-- FROM-only foreign table (should be dropped in TO)
+CREATE FOREIGN TABLE test_schema.foreign_logs (
+    id BIGINT NOT NULL,
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE
+) SERVER test_foreign_server
+OPTIONS (schema_name 'public', table_name 'logs');
+
+-- =============================================================================
+-- PG14–18 feature test: Extended statistics (PG10+)
+-- =============================================================================
+-- FROM: statistics with dependencies and ndistinct.
+-- TO: modified (added mcv kind), plus a new statistics object.
+-- Also: FROM has a stat that is removed in TO.
+CREATE STATISTICS test_schema.stat_users_email_status (dependencies, ndistinct)
+    ON email, status FROM test_schema.users;
+
+-- FROM-only statistics (should be dropped in TO)
+CREATE STATISTICS test_schema.stat_products_old (dependencies)
+    ON name, status FROM test_schema.products;
+
+-- =============================================================================
+-- PG18 feature test: NOT ENFORCED constraints (PG18+)
+-- =============================================================================
+-- FROM: regular enforced CHECK constraint.
+-- TO: same constraint with NOT ENFORCED flag.
+-- Note: Requires PostgreSQL 18+. Comment out if testing on earlier versions.
+ALTER TABLE test_schema.products ADD CONSTRAINT chk_products_sku_format
+    CHECK (sku ~ '^[A-Z]{2,4}-[0-9]+$');
+
+-- =============================================================================
+-- PG18 feature test: Virtual generated columns (PG18+)
+-- =============================================================================
+-- FROM: plain computed column (not generated).
+-- TO: GENERATED ALWAYS AS ... VIRTUAL column.
+-- Note: Requires PostgreSQL 18+.
+CREATE TABLE test_schema.virtual_gen_test (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    full_name VARCHAR(101) NOT NULL
+);
+
+-- =============================================================================
 -- Grants comparison test (FROM side)
 -- =============================================================================
 -- These GRANT statements establish the FROM baseline for grant comparison.

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -1180,6 +1180,159 @@ CREATE TABLE test_schema.test_identity (
 );
 
 -- =============================================================================
+-- PG14–18 feature test: Exclusion constraints (btree_gist)
+-- =============================================================================
+-- TO: table with exclusion constraint (unchanged) plus new column.
+-- shift_schedule removed (FROM-only → should be dropped).
+-- New: booking_slots table with exclusion constraint (TO-only → should be created).
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
+
+CREATE TABLE test_schema.reservations (
+    id SERIAL PRIMARY KEY,
+    room_id INTEGER NOT NULL,
+    during TSTZRANGE NOT NULL,
+    guest_name VARCHAR(255),  -- NEW column in TO
+    EXCLUDE USING gist (room_id WITH =, during WITH &&)
+);
+
+-- shift_schedule removed (FROM-only)
+
+-- TO-only exclusion constraint table (should be created)
+CREATE TABLE test_schema.booking_slots (
+    id SERIAL PRIMARY KEY,
+    resource_id INTEGER NOT NULL,
+    slot TSTZRANGE NOT NULL,
+    EXCLUDE USING gist (resource_id WITH =, slot WITH &&)
+);
+
+-- =============================================================================
+-- PG14–18 feature test: NULLS NOT DISTINCT (PG15+)
+-- =============================================================================
+-- TO: UNIQUE NULLS NOT DISTINCT (only one NULL allowed).
+-- FROM had standard UNIQUE.
+CREATE TABLE test_schema.unique_nulls_test (
+    id SERIAL PRIMARY KEY,
+    code VARCHAR(50),
+    CONSTRAINT uq_unique_nulls_code UNIQUE NULLS NOT DISTINCT (code)
+);
+
+-- =============================================================================
+-- PG14–18 feature test: NO INHERIT constraint flag
+-- =============================================================================
+-- TO: same CHECK constraint with NO INHERIT flag added.
+ALTER TABLE test_schema.categories ADD CONSTRAINT chk_categories_sort_order
+    CHECK (sort_order >= 0) NO INHERIT;
+
+-- =============================================================================
+-- PG14–18 feature test: Column STORAGE and COMPRESSION (PG14+)
+-- =============================================================================
+-- TO: STORAGE changed to EXTERNAL on payload, compression set to lz4 on blob.
+CREATE TABLE test_schema.storage_test (
+    id SERIAL PRIMARY KEY,
+    payload TEXT,
+    blob BYTEA
+);
+ALTER TABLE test_schema.storage_test ALTER COLUMN payload SET STORAGE EXTERNAL;
+ALTER TABLE test_schema.storage_test ALTER COLUMN blob SET STORAGE EXTERNAL;
+-- Note: COMPRESSION lz4 requires PG14+ compiled --with-lz4.
+-- Uncomment below if available:
+-- ALTER TABLE test_schema.storage_test ALTER COLUMN blob SET COMPRESSION lz4;
+
+-- =============================================================================
+-- PG14–18 feature test: SECURITY INVOKER views (PG15+)
+-- =============================================================================
+-- TO: same view definition but WITH (security_invoker = true).
+CREATE VIEW test_schema.security_invoker_view
+WITH (security_invoker = true)
+AS
+SELECT id, username, email
+FROM test_schema.users
+WHERE status = 'active';
+
+-- =============================================================================
+-- PG14–18 feature test: Range types
+-- =============================================================================
+-- TO: float_range without subtype_diff (modified → drop+recreate).
+-- old_range removed (FROM-only → should be dropped).
+-- int_range added (TO-only → should be created).
+CREATE TYPE test_schema.float_range AS RANGE (
+    SUBTYPE = float8
+);
+
+-- old_range removed (FROM-only)
+
+CREATE TYPE test_schema.int_range AS RANGE (
+    SUBTYPE = int4
+);
+
+-- =============================================================================
+-- PG14–18 feature test: Foreign tables (postgres_fdw)
+-- =============================================================================
+-- TO: foreign table modified (column type widened, new column added).
+-- foreign_logs removed (FROM-only → should be dropped).
+-- foreign_products added (TO-only → should be created).
+CREATE EXTENSION IF NOT EXISTS postgres_fdw WITH SCHEMA public;
+
+CREATE SERVER test_foreign_server
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (host 'localhost', dbname 'postgres');
+
+-- TO: modified foreign table (username widened, status column added)
+CREATE FOREIGN TABLE test_schema.foreign_users (
+    id INTEGER NOT NULL,
+    username VARCHAR(100),
+    email VARCHAR(255),
+    status VARCHAR(20)
+) SERVER test_foreign_server
+OPTIONS (schema_name 'public', table_name 'users');
+
+-- foreign_logs removed (FROM-only)
+
+-- TO-only foreign table (should be created)
+CREATE FOREIGN TABLE test_schema.foreign_products (
+    product_id UUID,
+    name VARCHAR(255),
+    price NUMERIC(10,2)
+) SERVER test_foreign_server
+OPTIONS (schema_name 'public', table_name 'products');
+
+-- =============================================================================
+-- PG14–18 feature test: Extended statistics (PG10+)
+-- =============================================================================
+-- TO: modified statistics (added mcv kind).
+-- stat_products_old removed (FROM-only → should be dropped).
+-- stat_products_new added (TO-only → should be created).
+CREATE STATISTICS test_schema.stat_users_email_status (dependencies, ndistinct, mcv)
+    ON email, status FROM test_schema.users;
+
+-- stat_products_old removed (FROM-only)
+
+-- TO-only statistics (should be created)
+CREATE STATISTICS test_schema.stat_products_new (ndistinct)
+    ON name, category_id FROM test_schema.products;
+
+-- =============================================================================
+-- PG18 feature test: NOT ENFORCED constraints (PG18+)
+-- =============================================================================
+-- TO: same constraint with NOT ENFORCED flag.
+-- Note: Requires PostgreSQL 18+. Comment out if testing on earlier versions.
+ALTER TABLE test_schema.products ADD CONSTRAINT chk_products_sku_format
+    CHECK (sku ~ '^[A-Z]{2,4}-[0-9]+$') NOT ENFORCED;
+
+-- =============================================================================
+-- PG18 feature test: Virtual generated columns (PG18+)
+-- =============================================================================
+-- TO: full_name is now GENERATED ALWAYS AS ... VIRTUAL.
+-- Note: Requires PostgreSQL 18+.
+-- On PG < 18, use STORED instead or comment out.
+CREATE TABLE test_schema.virtual_gen_test (
+    id SERIAL PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    full_name VARCHAR(101) GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
+);
+
+-- =============================================================================
 -- Grants comparison test (TO side)
 -- =============================================================================
 -- These GRANT statements establish the TO target for grant comparison.

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -1322,9 +1322,8 @@ ALTER TABLE test_schema.products ADD CONSTRAINT chk_products_sku_format
 -- =============================================================================
 -- PG18 feature test: Virtual generated columns (PG18+)
 -- =============================================================================
--- TO: full_name is now GENERATED ALWAYS AS ... VIRTUAL.
--- Note: Requires PostgreSQL 18+.
--- On PG < 18, use STORED instead or comment out.
+-- TO: full_name is now GENERATED ALWAYS AS ... STORED.
+-- Note: On PostgreSQL 18+ this could also be VIRTUAL.
 CREATE TABLE test_schema.virtual_gen_test (
     id SERIAL PRIMARY KEY,
     first_name VARCHAR(50) NOT NULL,


### PR DESCRIPTION
Features:
  - Changed `coninhcount` i16 -> i32 to support PG14+.
  - Added PostgreSQL 14–18 support:
      - Virtual generated columns (`GENERATED ALWAYS AS (...) VIRTUAL`).
      - `NOT ENFORCED` / `ENFORCED` constraints with ALTER support.
      - Temporal primary key and unique constraints (`WITHOUT OVERLAPS`).
      - Exclusion constraints (`contype 'x'`) support.
      - Named NOT NULL constraints (PG18 `contype 'n'`).
      - `NULLS NOT DISTINCT` for unique constraints and indexes.
      - `NO INHERIT` constraint flag with ALTER support.
      - Table access method (`USING`) with `ALTER TABLE SET ACCESS METHOD`.
      - Column `STORAGE` and `COMPRESSION` settings with ALTER support.
      - `SECURITY INVOKER` views with ALTER SET/RESET support.
      - Unlogged sequences (`CREATE UNLOGGED SEQUENCE`) with ALTER support.
      - `MAINTAIN` privilege for table ACLs.
      - Range and multirange type support (`CREATE TYPE AS RANGE`), including
          `pg_range` metadata fetch (subtype, collation, opclass, canonical,
          subdiff, multirange name) with PG13/PG14 compatibility.
  - New object types:
      - Foreign tables: full support for `CREATE FOREIGN TABLE`, `ALTER`,
          `DROP`, column management, table/column options, and comparison.
      - Extended statistics: `CREATE STATISTICS`, `ALTER`, `DROP`, and
          comparison via `pg_statistic_ext`.