### PR TITLE
180 set unlogged set logged statements are not ordered by foreign key dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,7 +137,7 @@ jobs:
         FROM_USER=postgres
         FROM_PASSWORD=postgres
         FROM_DATABASE=a
-        FROM_SCHEME=test_schema|shared_schema|new_reporting_schema|data
+        FROM_SCHEME=test_schema|shared_schema|new_reporting_schema|data|test_order
         FROM_SSL=false
         FROM_DUMP=/tmp/a.dump
         TO_HOST=127.0.0.1
@@ -145,7 +145,7 @@ jobs:
         TO_USER=postgres
         TO_PASSWORD=postgres
         TO_DATABASE=b
-        TO_SCHEME=test_schema|shared_schema|new_reporting_schema|data
+        TO_SCHEME=test_schema|shared_schema|new_reporting_schema|data|test_order
         TO_SSL=false
         TO_DUMP=/tmp/b.dump
         OUTPUT=/tmp/output.sql

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,38 @@
 2026-05-14      v1.0.20
 
                 Bug fixes:
+                    - Fixed issue #180: `ALTER TABLE ... SET LOGGED|
+                      UNLOGGED` was emitted inline with the per-table
+                      alter loop in alphabetical order, which
+                      PostgreSQL rejects whenever an FK chain flips
+                      persistence in the same migration —
+                      `SET UNLOGGED` fails if any LOGGED table
+                      references the target, `SET LOGGED` fails if the
+                      target references any UNLOGGED one. Moved the
+                      emission out of `Table::build_alter_script` and
+                      into a dedicated `Comparer::emit_persistence_
+                      changes` phase that runs at the end of
+                      `compare_tables`: tables flipping to UNLOGGED are
+                      sorted leaves-before-roots (reverse FK topo),
+                      tables flipping to LOGGED are sorted
+                      roots-before-leaves (forward FK topo), each via
+                      `Self::topo_order_within_subset` over an FK
+                      adjacency derived from the TO-side constraint
+                      definitions (parsed by `Self::parse_fk_
+                      referenced_table`). Owned sequences also get
+                      cleaner output: `Sequence::is_only_persistence_
+                      change` lets `compare_sequences` skip the entire
+                      `ALTER SEQUENCE` for sequences whose only diff is
+                      `is_unlogged` and whose owning table is itself
+                      flipping persistence (PostgreSQL propagates the
+                      `ALTER TABLE SET LOGGED|UNLOGGED` to every owned
+                      sequence automatically, so the explicit emit was
+                      redundant), and `Sequence::get_alter_script_
+                      excluding_persistence` strips just the
+                      `ALTER SEQUENCE … SET LOGGED|UNLOGGED` line when
+                      the sequence has other diffs to emit but the
+                      owning table will still propagate the persistence
+                      flip.
                     - Fixed issue #179: when a routine was dropped or
                       its return type / arguments / argument defaults
                       changed, `DROP FUNCTION ... CASCADE` silently

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1067,6 +1067,32 @@ impl Comparer {
             .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
             .collect();
 
+        // Tables whose persistence is flipping in this migration. The
+        // table-level `ALTER TABLE SET LOGGED|UNLOGGED` (emitted by the
+        // FK-ordered phase at the end of `compare_tables`) automatically
+        // propagates to every owned sequence, so re-emitting the same
+        // SET on the sequence — or, when persistence is the *only*
+        // diff, the entire ALTER SEQUENCE block — is redundant noise.
+        // See issue #180.
+        let tables_flipping_persistence: HashMap<(&str, &str), bool> = self
+            .to
+            .tables
+            .iter()
+            .filter_map(|to_table| {
+                let from_table = from_table_map
+                    .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                    .map(|&i| &self.from.tables[i])?;
+                from_table
+                    .persistence_change_for(to_table)
+                    .map(|new_unlogged| {
+                        (
+                            (to_table.schema.as_str(), to_table.name.as_str()),
+                            new_unlogged,
+                        )
+                    })
+            })
+            .collect();
+
         // We will find all new sequences from "to" dump that are not in "from" dump
         // and we will find all existing sequences in both dumps with different hashes
         // and add them to the script.
@@ -1096,11 +1122,31 @@ impl Comparer {
                     continue;
                 }
                 if Self::hashes_differ(&from_sequence.hash, &sequence.hash) {
+                    // Determine whether the owning table — if any — is
+                    // also flipping persistence in this migration.
+                    let owning_table_flipping = match (
+                        sequence.owned_by_schema.as_deref(),
+                        sequence.owned_by_table.as_deref(),
+                    ) {
+                        (Some(s), Some(t)) => tables_flipping_persistence.contains_key(&(s, t)),
+                        _ => false,
+                    };
+                    if owning_table_flipping && sequence.is_only_persistence_change(from_sequence) {
+                        // The whole ALTER SEQUENCE is redundant — the
+                        // owning table's `ALTER TABLE SET LOGGED|
+                        // UNLOGGED` propagates to this sequence on its
+                        // own. Suppress the entire emit (issue #180).
+                        continue;
+                    }
                     self.script.push_str(
                         format!("/* Sequence: {}.{}*/\n", sequence.schema, sequence.name).as_str(),
                     );
-                    self.script
-                        .push_str(sequence.get_alter_script(from_sequence).as_str());
+                    let alter = if owning_table_flipping {
+                        sequence.get_alter_script_excluding_persistence(from_sequence)
+                    } else {
+                        sequence.get_alter_script(from_sequence)
+                    };
+                    self.script.push_str(alter.as_str());
                 }
             } else {
                 // Check if the sequence is owned by a column that is an identity column or serial type.
@@ -1798,9 +1844,203 @@ impl Comparer {
                 .push_str(table.get_trigger_script().as_str());
         }
 
+        self.emit_persistence_changes();
+
         self.script
             .append_block("\n/* ---> Tables: End section --------------- */");
         Ok(())
+    }
+
+    /// Emit `ALTER TABLE ... SET LOGGED|UNLOGGED` statements in FK
+    /// topological order. PostgreSQL rejects the conversion when a
+    /// related table is in the wrong persistence state at the moment
+    /// the ALTER runs:
+    ///
+    ///   * `SET UNLOGGED` fails if any LOGGED table references the
+    ///     target via FK — every FK-referencing table must already be
+    ///     UNLOGGED.  Ordering: leaves before roots (reverse topo).
+    ///   * `SET LOGGED`   fails if the target references any UNLOGGED
+    ///     table via FK — every FK-referenced table must already be
+    ///     LOGGED.  Ordering: roots before leaves (forward topo).
+    ///
+    /// `Table::build_alter_script` deliberately omits the persistence
+    /// line so this single phase owns the order. See issue #180.
+    fn emit_persistence_changes(&mut self) {
+        let from_table_map: HashMap<(&str, &str), &Table> = self
+            .from
+            .tables
+            .iter()
+            .map(|t| ((t.schema.as_str(), t.name.as_str()), t))
+            .collect();
+
+        // Index every TO table once; the FK adjacency below and the
+        // subset orderings refer to tables by their position in
+        // `self.to.tables` to avoid borrow-tied pointer identity.
+        let to_index_by_key: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
+        // Partition into the two flip directions; tables newly created
+        // (no FROM counterpart) do not need a SET — they're created
+        // with their TO-side persistence inline.
+        let mut to_unlogged: Vec<usize> = Vec::new();
+        let mut to_logged: Vec<usize> = Vec::new();
+        for (idx, to_table) in self.to.tables.iter().enumerate() {
+            let Some(from_table) = from_table_map
+                .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                .copied()
+            else {
+                continue;
+            };
+            match from_table.persistence_change_for(to_table) {
+                Some(true) => to_unlogged.push(idx),
+                Some(false) => to_logged.push(idx),
+                None => {}
+            }
+        }
+
+        if to_unlogged.is_empty() && to_logged.is_empty() {
+            return;
+        }
+
+        // FK adjacency on the TO side (the live FK shape at the SET
+        // point is whatever `compare_tables` produced, which converges
+        // on TO). `fk_targets[i]` holds the indices of tables that
+        // table `i` references via FK — i.e. `i` *depends on* those.
+        let mut fk_targets: Vec<HashSet<usize>> = vec![HashSet::new(); self.to.tables.len()];
+        for (i, table) in self.to.tables.iter().enumerate() {
+            for c in &table.constraints {
+                if !c.constraint_type.eq_ignore_ascii_case("foreign key") {
+                    continue;
+                }
+                let Some(def) = &c.definition else { continue };
+                if let Some((schema, name)) = Self::parse_fk_referenced_table(def)
+                    && let Some(&j) = to_index_by_key.get(&(schema.as_str(), name.as_str()))
+                    && j != i
+                {
+                    fk_targets[i].insert(j);
+                }
+            }
+        }
+
+        // For SET UNLOGGED we want leaves (referencers) first. The
+        // generic toposort returns `dependencies before dependents`
+        // when fed `depends_on[i] = nodes i references`, so we reverse
+        // its output to get the dependent-first order this direction
+        // requires.
+        if !to_unlogged.is_empty() {
+            for table_idx in
+                Self::topo_order_within_subset(&to_unlogged, &fk_targets, &self.to.tables, true)
+            {
+                let table = &self.to.tables[table_idx];
+                self.script.append_block(&format!(
+                    "alter table {}.{} set unlogged;",
+                    table.schema, table.name
+                ));
+            }
+        }
+
+        // For SET LOGGED we want roots (referenced tables) first —
+        // forward topo order is exactly what we need.
+        if !to_logged.is_empty() {
+            for table_idx in
+                Self::topo_order_within_subset(&to_logged, &fk_targets, &self.to.tables, false)
+            {
+                let table = &self.to.tables[table_idx];
+                self.script.append_block(&format!(
+                    "alter table {}.{} set logged;",
+                    table.schema, table.name
+                ));
+            }
+        }
+    }
+
+    /// Order `subset` (absolute indices into `tables`) by FK
+    /// dependencies restricted to the subset itself. Edges to tables
+    /// outside the subset are ignored: a table the migration isn't
+    /// flipping doesn't constrain the SET ordering — only PostgreSQL's
+    /// runtime check against the live state does, and that's the
+    /// user's problem (they would have to add the missing flip to the
+    /// migration). With `dependents_first = true` returns reverse-topo
+    /// (leaves first — `SET UNLOGGED`); else forward-topo (roots
+    /// first — `SET LOGGED`). Result is a permutation of `subset`.
+    fn topo_order_within_subset(
+        subset: &[usize],
+        fk_targets: &[HashSet<usize>],
+        tables: &[Table],
+        dependents_first: bool,
+    ) -> Vec<usize> {
+        let n = subset.len();
+        let pos_in_subset: HashMap<usize, usize> = subset
+            .iter()
+            .enumerate()
+            .map(|(pos, &abs)| (abs, pos))
+            .collect();
+
+        let mut depends_on: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+        for (pos, &abs_idx) in subset.iter().enumerate() {
+            for &target_abs in &fk_targets[abs_idx] {
+                if let Some(&target_pos) = pos_in_subset.get(&target_abs)
+                    && target_pos != pos
+                {
+                    depends_on[pos].insert(target_pos);
+                }
+            }
+        }
+
+        let mut sorted = Self::kahn_toposort(n, &depends_on, |i| {
+            let t = &tables[subset[i]];
+            (t.schema.to_lowercase(), t.name.to_lowercase())
+        });
+        if dependents_first {
+            sorted.reverse();
+        }
+        sorted.into_iter().map(|pos| subset[pos]).collect()
+    }
+
+    /// Pull the `schema.name` of the table targeted by an FK constraint
+    /// definition (`pg_get_constraintdef` output, e.g.
+    /// `FOREIGN KEY (col) REFERENCES schema.table(col)`). Tolerates
+    /// quoted identifiers; returns `None` when the definition isn't
+    /// recognisably an FK or the referenced identifier is unqualified.
+    fn parse_fk_referenced_table(def: &str) -> Option<(String, String)> {
+        let lower = def.to_lowercase();
+        let start = lower.find("references ")? + "references ".len();
+        let after = &def[start..];
+        // Scan a single qualified identifier: identifier chars, dot,
+        // or quoted segments. Stop at the first non-identifier byte
+        // outside quotes (typically `(` for the column list).
+        let mut end = 0;
+        let mut in_quotes = false;
+        for (i, ch) in after.char_indices() {
+            if ch == '"' {
+                in_quotes = !in_quotes;
+                end = i + ch.len_utf8();
+                continue;
+            }
+            if in_quotes {
+                end = i + ch.len_utf8();
+                continue;
+            }
+            if ch.is_alphanumeric() || ch == '_' || ch == '.' {
+                end = i + ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        let target = &after[..end];
+        let dot = target.find('.')?;
+        let schema = target[..dot].trim_matches('"').to_string();
+        let name = target[dot + 1..].trim_matches('"').to_string();
+        if schema.is_empty() || name.is_empty() {
+            None
+        } else {
+            Some((schema, name))
+        }
     }
 
     // Comparing foreign keys

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1865,6 +1865,26 @@ impl Comparer {
     ///
     /// `Table::build_alter_script` deliberately omits the persistence
     /// line so this single phase owns the order. See issue #180.
+    ///
+    /// **FK timing analysis** (issue #184 review thread): this phase
+    /// runs at the end of `compare_tables`, before `compare_foreign_
+    /// keys` has had a chance to add new FKs. The migration order is:
+    ///
+    ///   1. `compare_tables` per-table loop drops FKs whose
+    ///      definition changed (and FROM-only FKs alongside their
+    ///      table). Unchanged FKs are left in place.
+    ///   2. `emit_persistence_changes` (this method) runs the SETs.
+    ///   3. `compare_foreign_keys` re-adds modified FKs and creates
+    ///      new ones.
+    ///
+    /// So the live FK graph at the SET point is exactly the
+    /// **intersection** of FROM and TO by `(table, fk-name,
+    /// definition)` — neither the soon-to-be-added new FKs nor the
+    /// already-dropped modified FKs are active. The adjacency below
+    /// is built from that intersection (rather than the TO-side
+    /// constraints alone) so we don't impose ordering for FKs that
+    /// won't exist at the SET point and so we don't miss ordering
+    /// for FKs that DO exist but will later be dropped+re-added.
     fn emit_persistence_changes(&mut self) {
         let from_table_map: HashMap<(&str, &str), &Table> = self
             .from
@@ -1907,17 +1927,41 @@ impl Comparer {
             return;
         }
 
-        // FK adjacency on the TO side (the live FK shape at the SET
-        // point is whatever `compare_tables` produced, which converges
-        // on TO). `fk_targets[i]` holds the indices of tables that
-        // table `i` references via FK — i.e. `i` *depends on* those.
+        // FK adjacency restricted to the **live** FK set — FKs that
+        // exist in BOTH FROM and TO with the same definition. See the
+        // doc comment above this method for the timing rationale.
+        // `fk_targets[i]` holds the indices of tables that table `i`
+        // references via FK — i.e. `i` *depends on* those.
         let mut fk_targets: Vec<HashSet<usize>> = vec![HashSet::new(); self.to.tables.len()];
-        for (i, table) in self.to.tables.iter().enumerate() {
-            for c in &table.constraints {
+        for (i, to_table) in self.to.tables.iter().enumerate() {
+            // Lift the matching FROM table once so the FK lookup
+            // doesn't pay a per-constraint hashmap miss.
+            let from_table = from_table_map
+                .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                .copied();
+            for c in &to_table.constraints {
                 if !c.constraint_type.eq_ignore_ascii_case("foreign key") {
                     continue;
                 }
                 let Some(def) = &c.definition else { continue };
+                // Live edge requires the same FK to exist in FROM with
+                // the same definition. A new FK (TO-only) won't be
+                // present at the SET point — `compare_foreign_keys`
+                // adds it later. A modified FK was dropped in the
+                // per-table ALTER loop and is also absent here. Both
+                // get filtered out.
+                let live = from_table
+                    .map(|ft| {
+                        ft.constraints.iter().any(|fc| {
+                            fc.name == c.name
+                                && fc.constraint_type.eq_ignore_ascii_case("foreign key")
+                                && fc.definition.as_deref() == c.definition.as_deref()
+                        })
+                    })
+                    .unwrap_or(false);
+                if !live {
+                    continue;
+                }
                 if let Some((schema, name)) = Self::parse_fk_referenced_table(def)
                     && let Some(&j) = to_index_by_key.get(&(schema.as_str(), name.as_str()))
                     && j != i
@@ -2007,10 +2051,57 @@ impl Comparer {
     /// `FOREIGN KEY (col) REFERENCES schema.table(col)`). Tolerates
     /// quoted identifiers; returns `None` when the definition isn't
     /// recognisably an FK or the referenced identifier is unqualified.
+    ///
+    /// The keyword scan is anchored to a whole-word match — a naive
+    /// `find("references ")` would false-match a column name like
+    /// `"references "` that happened to appear inside the FK column
+    /// list (or any earlier substring containing the literal text).
+    /// The schema/name split is quote-aware so a quoted identifier
+    /// that itself contains a literal `.`
+    /// (e.g. `REFERENCES "weird.schema"."t"(id)`) is split at the
+    /// dot OUTSIDE the quotes, not the first dot in byte order.
     fn parse_fk_referenced_table(def: &str) -> Option<(String, String)> {
         let lower = def.to_lowercase();
-        let start = lower.find("references ")? + "references ".len();
-        let after = &def[start..];
+        let bytes = lower.as_bytes();
+        let kw = b"references";
+        let kw_len = kw.len();
+
+        // Walk every occurrence of "references" until we find one that
+        // sits at an identifier word boundary AND is followed by
+        // whitespace — `pg_get_constraintdef` always renders the
+        // keyword that way. Substring matches inside quoted column
+        // names (the FK column list precedes the keyword) fail one of
+        // these checks: a quoted `"references"` is followed by `"`
+        // (not whitespace), `references_table` is followed by `_`
+        // (still an identifier char), and `xxx_references` is
+        // preceded by `_`.
+        let mut search_from = 0;
+        let kw_pos = loop {
+            if search_from + kw_len > bytes.len() {
+                return None;
+            }
+            let rel = lower[search_from..].find("references")?;
+            let pos = search_from + rel;
+            let left_ok = pos == 0
+                || !{
+                    let b = bytes[pos - 1];
+                    b.is_ascii_alphanumeric() || b == b'_' || b == b'"'
+                };
+            let after_kw = pos + kw_len;
+            let right_ok = after_kw < bytes.len() && bytes[after_kw].is_ascii_whitespace();
+            if left_ok && right_ok {
+                break pos;
+            }
+            // Advance one byte to keep ASCII-byte indices valid; the
+            // haystack is `lower` which is purely ASCII at byte 0 of
+            // each match candidate (because `find` lands on the
+            // ASCII keyword `references`).
+            search_from = pos + 1;
+        };
+
+        // Skip the keyword and the run of whitespace immediately after.
+        let after = (def[kw_pos + kw_len..]).trim_start();
+
         // Scan a single qualified identifier: identifier chars, dot,
         // or quoted segments. Stop at the first non-identifier byte
         // outside quotes (typically `(` for the column list).
@@ -2033,7 +2124,27 @@ impl Comparer {
             }
         }
         let target = &after[..end];
-        let dot = target.find('.')?;
+        Self::split_qualified_name_quote_aware(target)
+    }
+
+    /// Split a `schema.name` identifier at the first dot that lives
+    /// OUTSIDE any double-quoted segment. PostgreSQL allows quoted
+    /// identifiers to contain literal dots (`"weird.schema"`), so the
+    /// naive `target.find('.')` would split inside the quoted segment
+    /// and produce an invalid pair.
+    fn split_qualified_name_quote_aware(target: &str) -> Option<(String, String)> {
+        let bytes = target.as_bytes();
+        let mut in_quotes = false;
+        let mut split_at = None;
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'"' {
+                in_quotes = !in_quotes;
+            } else if b == b'.' && !in_quotes {
+                split_at = Some(i);
+                break;
+            }
+        }
+        let dot = split_at?;
         let schema = target[..dot].trim_matches('"').to_string();
         let name = target[dot + 1..].trim_matches('"').to_string();
         if schema.is_empty() || name.is_empty() {

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2060,8 +2060,20 @@ impl Comparer {
     /// that itself contains a literal `.`
     /// (e.g. `REFERENCES "weird.schema"."t"(id)`) is split at the
     /// dot OUTSIDE the quotes, not the first dot in byte order.
+    ///
+    /// The case-insensitive haystack is built with [`str::to_ascii_
+    /// lowercase`] rather than [`str::to_lowercase`]: the latter can
+    /// change byte length for some non-ASCII characters (e.g. capital
+    /// Turkish dotted I, which lowercases into a multi-character
+    /// sequence with a different UTF-8 length), and we slice back
+    /// into the original `def` using offsets that came from the
+    /// haystack — a length-changing lowercasing would leave those
+    /// offsets pointing inside a UTF-8 codepoint and panic.
+    /// `to_ascii_lowercase` is byte-length-preserving (only ASCII
+    /// letters change, every other byte is left intact) and the
+    /// keyword `references` is pure ASCII, so it's the right tool.
     fn parse_fk_referenced_table(def: &str) -> Option<(String, String)> {
-        let lower = def.to_lowercase();
+        let lower = def.to_ascii_lowercase();
         let bytes = lower.as_bytes();
         let kw = b"references";
         let kw_len = kw.len();

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -8239,6 +8239,480 @@ async fn issue179_full_drop_recreates_dependents_when_to_keeps_them() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Issue #180 — SET UNLOGGED / SET LOGGED statements must respect FK
+// dependencies (PostgreSQL rejects an out-of-order conversion), and
+// owned sequences should not redundantly re-emit the persistence flip
+// the table cascade already propagates.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a logged/unlogged-controlled table with a single FK to another
+/// table in the same schema, named with a numeric `id` PK column. Used
+/// by the issue-#180 ordering tests.
+fn issue180_logged_table(
+    schema: &str,
+    name: &str,
+    is_unlogged: bool,
+    fk_target: Option<(&str, &str, &str)>,
+) -> Table {
+    let mut id_col = int_column(schema, name, "id", 1);
+    id_col.is_nullable = false;
+
+    let mut constraints: Vec<TableConstraint> = vec![TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: schema.to_string(),
+        name: format!("{name}_pkey"),
+        table_name: name.to_string(),
+        constraint_type: "PRIMARY KEY".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("PRIMARY KEY (id)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    }];
+
+    let mut columns = vec![id_col];
+    if let Some((fk_col, fk_schema, fk_table)) = fk_target {
+        let mut ref_col = int_column(schema, name, fk_col, 2);
+        ref_col.is_nullable = true;
+        columns.push(ref_col);
+        constraints.push(TableConstraint {
+            catalog: "postgres".to_string(),
+            schema: schema.to_string(),
+            name: format!("{name}_{fk_col}_fkey"),
+            table_name: name.to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some(format!(
+                "FOREIGN KEY ({fk_col}) REFERENCES {fk_schema}.{fk_table}(id)"
+            )),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+            comment: None,
+        });
+    }
+
+    let mut table = Table::new(
+        schema.to_string(),
+        name.to_string(),
+        schema.to_string(),
+        name.to_string(),
+        "postgres".to_string(),
+        None,
+        columns,
+        constraints,
+        vec![],
+        vec![],
+        None,
+    );
+    table.is_unlogged = is_unlogged;
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue180_set_unlogged_orders_dependents_before_referenced() {
+    // FROM: three logged tables with FK chain
+    //   child -> parent -> grandparent.
+    // TO:   the same three tables, all UNLOGGED.
+    // PostgreSQL refuses `SET UNLOGGED` on a table while a LOGGED table
+    // still references it, so the conversion order must be leaves
+    // first: child, then parent, then grandparent.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        false,
+        None,
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        false,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        false,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        true,
+        None,
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        true,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_child = script
+        .find("alter table test_order.child set unlogged;")
+        .expect("child SET UNLOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set unlogged;")
+        .expect("parent SET UNLOGGED must be emitted");
+    let pos_grand = script
+        .find("alter table test_order.grandparent set unlogged;")
+        .expect("grandparent SET UNLOGGED must be emitted");
+
+    assert!(
+        pos_child < pos_parent && pos_parent < pos_grand,
+        "SET UNLOGGED must be ordered child -> parent -> grandparent (FK leaves first); got\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_set_logged_orders_referenced_before_dependents() {
+    // Reverse direction: all UNLOGGED -> all LOGGED.
+    // PostgreSQL refuses `SET LOGGED` while the table still references
+    // an UNLOGGED one, so order must be roots first: grandparent, then
+    // parent, then child.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        true,
+        None,
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        true,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        false,
+        None,
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        false,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        false,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_grand = script
+        .find("alter table test_order.grandparent set logged;")
+        .expect("grandparent SET LOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set logged;")
+        .expect("parent SET LOGGED must be emitted");
+    let pos_child = script
+        .find("alter table test_order.child set logged;")
+        .expect("child SET LOGGED must be emitted");
+
+    assert!(
+        pos_grand < pos_parent && pos_parent < pos_child,
+        "SET LOGGED must be ordered grandparent -> parent -> child (FK roots first); got\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_persistence_change_does_not_emit_inline_inside_alter_table() {
+    // A table-level ALTER (e.g. add column) MUST NOT carry a SET
+    // UNLOGGED line — that would re-introduce the alphabetical ordering
+    // bug. The persistence flip is owned by the dedicated phase.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+
+    let mut to_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![
+            int_column("test_order", "items", "id", 1),
+            int_column("test_order", "items", "name", 2),
+        ],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    to_table.is_unlogged = true;
+    to_table.hash();
+
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    // SET UNLOGGED is still emitted, but only once and after the ADD
+    // COLUMN — not interleaved inside the per-table ALTER block.
+    let add_pos = script
+        .find("alter table test_order.items add column name")
+        .expect("add column must be emitted");
+    let set_pos = script
+        .find("alter table test_order.items set unlogged;")
+        .expect("set unlogged must be emitted by the dedicated phase");
+    assert!(
+        add_pos < set_pos,
+        "SET UNLOGGED must come from the dedicated phase, after the per-table ALTER: {}",
+        script
+    );
+    assert_eq!(
+        script.matches("set unlogged").count(),
+        1,
+        "SET UNLOGGED must be emitted exactly once (no inline + dedicated double-up): {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_owned_sequence_persistence_only_diff_is_skipped() {
+    // A sequence whose owning table flips persistence — and which has
+    // no other diff — produces a redundant `ALTER SEQUENCE ... SET
+    // UNLOGGED` followed by the full clause list. Both are noise: the
+    // table's `ALTER TABLE ... SET UNLOGGED` already cascades to all
+    // owned sequences. Suppress the entire ALTER SEQUENCE.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+
+    let mut to_table = from_table.clone();
+    to_table.is_unlogged = true;
+    to_table.hash();
+
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let make_seq = |is_unlogged: bool| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "items_id_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(1),
+            Some(1),
+            Some("test_order".to_string()),
+            Some("items".to_string()),
+            Some("id".to_string()),
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false));
+    to_dump.sequences.push(make_seq(true));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq"),
+        "owned-sequence persistence-only flip must be suppressed (table cascade handles it); got:\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_owned_sequence_other_diff_skips_only_persistence_line() {
+    // When the sequence has a real change (e.g. cache_size) AND the
+    // owning table is also flipping persistence, we still need the
+    // ALTER SEQUENCE — but not the `SET UNLOGGED|LOGGED` line, because
+    // the table cascade handles that.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+    let mut to_table = from_table.clone();
+    to_table.is_unlogged = true;
+    to_table.hash();
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let make_seq = |is_unlogged: bool, cache: i64| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "items_id_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(cache),
+            Some(1),
+            Some("test_order".to_string()),
+            Some("items".to_string()),
+            Some("id".to_string()),
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false, 1));
+    to_dump.sequences.push(make_seq(true, 5));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter sequence test_order.items_id_seq"),
+        "ALTER SEQUENCE must be emitted when non-persistence params changed: {}",
+        script
+    );
+    assert!(
+        script.contains("cache 5"),
+        "the changed cache value must be in the script: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
+        "SET UNLOGGED on owned sequence is redundant when the owning table is flipping persistence: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_standalone_sequence_persistence_change_still_emits_set() {
+    // A sequence not owned by any table (or owned by a table whose
+    // persistence is unchanged) must still get its own SET because no
+    // table cascade applies.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let make_seq = |is_unlogged: bool| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "global_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false));
+    to_dump.sequences.push(make_seq(true));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter sequence test_order.global_seq set unlogged"),
+        "standalone sequence must still emit SET UNLOGGED: {}",
+        script
+    );
+}
+
 #[tokio::test]
 async fn issue179_quoted_routine_names_match_unqualified_calls() {
     // PGC's dump query wraps `nspname` / `proname` with `quote_ident`,
@@ -8385,6 +8859,345 @@ async fn issue179_defaults_only_change_triggers_recreate() {
     assert!(
         script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
         "Phase 7 must recreate index on defaults-only change: {}",
+        script
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Issue #180 — `ALTER TABLE ... SET LOGGED|UNLOGGED` must be ordered by
+// FK dependencies, not by alphabetical table iteration. Owned sequences
+// must not redundantly re-emit their own SET (the table change
+// propagates).
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build an `id`-only table named `name` in `test_order`. `is_unlogged`
+/// controls the FROM/TO side; `fk_target` (when supplied) emits a single
+/// FK constraint from this table's `parent_id` column to the named
+/// table — this is the FK shape the issue example exercises.
+fn issue180_chain_table(name: &str, is_unlogged: bool, fk_target: Option<&str>) -> Table {
+    let mut id_col = int_column("test_order", name, "id", 1);
+    id_col.is_nullable = false;
+    let mut cols = vec![id_col];
+    let mut constraints = vec![TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "test_order".to_string(),
+        name: format!("{}_pkey", name),
+        table_name: name.to_string(),
+        constraint_type: "PRIMARY KEY".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("PRIMARY KEY (id)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    }];
+
+    if let Some(target) = fk_target {
+        cols.push(int_column("test_order", name, "parent_id", 2));
+        constraints.push(TableConstraint {
+            catalog: "postgres".to_string(),
+            schema: "test_order".to_string(),
+            name: format!("{}_parent_fk", name),
+            table_name: name.to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some(format!(
+                "FOREIGN KEY (parent_id) REFERENCES test_order.{}(id)",
+                target
+            )),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+            comment: None,
+        });
+    }
+
+    let mut table = Table::new(
+        "test_order".to_string(),
+        name.to_string(),
+        "test_order".to_string(),
+        name.to_string(),
+        "postgres".to_string(),
+        None,
+        cols,
+        constraints,
+        vec![],
+        vec![],
+        None,
+    );
+    table.is_unlogged = is_unlogged;
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue180_set_unlogged_orders_by_fk_dependents_first() {
+    // grandparent ← parent ← child (FK chain). All three flip from
+    // LOGGED to UNLOGGED. PostgreSQL rejects `SET UNLOGGED` on a table
+    // referenced by any LOGGED table, so the dependent (leaf) must be
+    // converted before its referenced parent. Required order:
+    // child → parent → grandparent.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump
+        .tables
+        .push(issue180_chain_table("grandparent", false, None));
+    from_dump
+        .tables
+        .push(issue180_chain_table("parent", false, Some("grandparent")));
+    from_dump
+        .tables
+        .push(issue180_chain_table("child", false, Some("parent")));
+    to_dump
+        .tables
+        .push(issue180_chain_table("grandparent", true, None));
+    to_dump
+        .tables
+        .push(issue180_chain_table("parent", true, Some("grandparent")));
+    to_dump
+        .tables
+        .push(issue180_chain_table("child", true, Some("parent")));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_child = script
+        .find("alter table test_order.child set unlogged;")
+        .expect("child SET UNLOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set unlogged;")
+        .expect("parent SET UNLOGGED must be emitted");
+    let pos_grand = script
+        .find("alter table test_order.grandparent set unlogged;")
+        .expect("grandparent SET UNLOGGED must be emitted");
+
+    assert!(
+        pos_child < pos_parent,
+        "child must be SET UNLOGGED before parent (FK leaf first): {}",
+        script
+    );
+    assert!(
+        pos_parent < pos_grand,
+        "parent must be SET UNLOGGED before grandparent (FK leaf first): {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_set_logged_orders_by_fk_roots_first() {
+    // Reverse direction: grandparent ← parent ← child (FK chain), all
+    // UNLOGGED in FROM, LOGGED in TO. PostgreSQL rejects `SET LOGGED`
+    // on a table that references any UNLOGGED table, so the referenced
+    // root must be converted before its dependents. Required order:
+    // grandparent → parent → child.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump
+        .tables
+        .push(issue180_chain_table("grandparent", true, None));
+    from_dump
+        .tables
+        .push(issue180_chain_table("parent", true, Some("grandparent")));
+    from_dump
+        .tables
+        .push(issue180_chain_table("child", true, Some("parent")));
+    to_dump
+        .tables
+        .push(issue180_chain_table("grandparent", false, None));
+    to_dump
+        .tables
+        .push(issue180_chain_table("parent", false, Some("grandparent")));
+    to_dump
+        .tables
+        .push(issue180_chain_table("child", false, Some("parent")));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_grand = script
+        .find("alter table test_order.grandparent set logged;")
+        .expect("grandparent SET LOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set logged;")
+        .expect("parent SET LOGGED must be emitted");
+    let pos_child = script
+        .find("alter table test_order.child set logged;")
+        .expect("child SET LOGGED must be emitted");
+
+    assert!(
+        pos_grand < pos_parent,
+        "grandparent must be SET LOGGED before parent (FK root first): {}",
+        script
+    );
+    assert!(
+        pos_parent < pos_child,
+        "parent must be SET LOGGED before child (FK root first): {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_persistence_only_change_skips_owned_sequence_alter() {
+    // A sequence whose owning table flips persistence must NOT emit
+    // its own ALTER SEQUENCE SET LOGGED|UNLOGGED — the table-level
+    // ALTER TABLE propagates to every owned sequence automatically.
+    // When persistence is the *only* diff, the entire ALTER SEQUENCE
+    // block is suppressed (no redundant `start with … increment by …`).
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_seq = Sequence::new(
+        "test_order".to_string(),
+        "items_id_seq".to_string(),
+        "postgres".to_string(),
+        "integer".to_string(),
+        Some(1),
+        Some(1),
+        Some(2147483647),
+        Some(1),
+        false,
+        Some(1),
+        Some(1),
+        Some("test_order".to_string()),
+        Some("items".to_string()),
+        Some("id".to_string()),
+    );
+    from_seq.is_unlogged = false;
+    from_seq.hash();
+    let mut to_seq = from_seq.clone();
+    to_seq.is_unlogged = true;
+    to_seq.hash();
+    from_dump.sequences.push(from_seq);
+    to_dump.sequences.push(to_seq);
+
+    // Owning table flips LOGGED → UNLOGGED.
+    from_dump
+        .tables
+        .push(issue180_chain_table("items", false, None));
+    to_dump
+        .tables
+        .push(issue180_chain_table("items", true, None));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
+        "owned sequence's SET UNLOGGED is redundant — table propagates: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq start with"),
+        "no `alter sequence … start with …` either — persistence was the only diff: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_sequence_with_other_changes_omits_persistence_line_only() {
+    // A sequence whose owning table flips persistence AND whose own
+    // parameters also change must still emit an ALTER SEQUENCE for the
+    // parameter diff — but NOT the SET LOGGED|UNLOGGED line, because
+    // the table-level ALTER propagates that change.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_seq = Sequence::new(
+        "test_order".to_string(),
+        "items_id_seq".to_string(),
+        "postgres".to_string(),
+        "integer".to_string(),
+        Some(1),
+        Some(1),
+        Some(2147483647),
+        Some(1),
+        false,
+        Some(1),
+        Some(1),
+        Some("test_order".to_string()),
+        Some("items".to_string()),
+        Some("id".to_string()),
+    );
+    from_seq.is_unlogged = false;
+    from_seq.hash();
+    let mut to_seq = from_seq.clone();
+    to_seq.is_unlogged = true;
+    // Real param diff: cache size change.
+    to_seq.cache_size = Some(50);
+    to_seq.hash();
+    from_dump.sequences.push(from_seq);
+    to_dump.sequences.push(to_seq);
+
+    from_dump
+        .tables
+        .push(issue180_chain_table("items", false, None));
+    to_dump
+        .tables
+        .push(issue180_chain_table("items", true, None));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
+        "owning table propagates SET — sequence must NOT emit its own SET: {}",
+        script
+    );
+    assert!(
+        script.contains("cache 50"),
+        "the real (non-persistence) diff must still be emitted: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_sequence_persistence_alone_emits_when_table_unchanged() {
+    // Defensive: if the owning table is *not* flipping persistence,
+    // the sequence's own SET must still be emitted (no propagation
+    // happens). Verifies we don't over-suppress.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_seq = Sequence::new(
+        "test_order".to_string(),
+        "loose_seq".to_string(),
+        "postgres".to_string(),
+        "integer".to_string(),
+        Some(1),
+        Some(1),
+        Some(2147483647),
+        Some(1),
+        false,
+        Some(1),
+        Some(1),
+        // No owning table.
+        None,
+        None,
+        None,
+    );
+    from_seq.is_unlogged = false;
+    from_seq.hash();
+    let mut to_seq = from_seq.clone();
+    to_seq.is_unlogged = true;
+    to_seq.hash();
+    from_dump.sequences.push(from_seq);
+    to_dump.sequences.push(to_seq);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter sequence test_order.loose_seq set unlogged"),
+        "standalone sequence's SET UNLOGGED must still be emitted: {}",
         script
     );
 }

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -8863,341 +8863,142 @@ async fn issue179_defaults_only_change_triggers_recreate() {
     );
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Issue #180 — `ALTER TABLE ... SET LOGGED|UNLOGGED` must be ordered by
-// FK dependencies, not by alphabetical table iteration. Owned sequences
-// must not redundantly re-emit their own SET (the table change
-// propagates).
-// ─────────────────────────────────────────────────────────────────────
-
-/// Build an `id`-only table named `name` in `test_order`. `is_unlogged`
-/// controls the FROM/TO side; `fk_target` (when supplied) emits a single
-/// FK constraint from this table's `parent_id` column to the named
-/// table — this is the FK shape the issue example exercises.
-fn issue180_chain_table(name: &str, is_unlogged: bool, fk_target: Option<&str>) -> Table {
-    let mut id_col = int_column("test_order", name, "id", 1);
-    id_col.is_nullable = false;
-    let mut cols = vec![id_col];
-    let mut constraints = vec![TableConstraint {
-        catalog: "postgres".to_string(),
-        schema: "test_order".to_string(),
-        name: format!("{}_pkey", name),
-        table_name: name.to_string(),
-        constraint_type: "PRIMARY KEY".to_string(),
-        is_deferrable: false,
-        initially_deferred: false,
-        definition: Some("PRIMARY KEY (id)".to_string()),
-        coninhcount: 0,
-        is_enforced: true,
-        no_inherit: false,
-        nulls_not_distinct: false,
-        comment: None,
-    }];
-
-    if let Some(target) = fk_target {
-        cols.push(int_column("test_order", name, "parent_id", 2));
-        constraints.push(TableConstraint {
-            catalog: "postgres".to_string(),
-            schema: "test_order".to_string(),
-            name: format!("{}_parent_fk", name),
-            table_name: name.to_string(),
-            constraint_type: "FOREIGN KEY".to_string(),
-            is_deferrable: false,
-            initially_deferred: false,
-            definition: Some(format!(
-                "FOREIGN KEY (parent_id) REFERENCES test_order.{}(id)",
-                target
-            )),
-            coninhcount: 0,
-            is_enforced: true,
-            no_inherit: false,
-            nulls_not_distinct: false,
-            comment: None,
-        });
-    }
-
-    let mut table = Table::new(
-        "test_order".to_string(),
-        name.to_string(),
-        "test_order".to_string(),
-        name.to_string(),
-        "postgres".to_string(),
-        None,
-        cols,
-        constraints,
-        vec![],
-        vec![],
-        None,
+#[test]
+fn issue180_parse_fk_referenced_table_word_boundary() {
+    // PR #184 review: a naive `find("references ")` substring match
+    // can pick up the literal text inside a quoted column name in the
+    // FK column list. The matcher must be anchored to a word boundary
+    // and the keyword must be followed by whitespace.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col_a) REFERENCES public.target(id)"),
+        Some(("public".to_string(), "target".to_string())),
+        "happy-path FK definition must parse"
     );
-    table.is_unlogged = is_unlogged;
-    table.hash();
-    table
+    // Column literally named `"references "` (with trailing space) in
+    // the FK column list. Naive substring search would lock onto it
+    // before the real keyword and parse garbage.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"references \", col_b) REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // Column named `references_count` — substring match on
+    // "references" without the right-side word-boundary check would
+    // see this column first and try to parse what follows.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (references_count) REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+}
+
+#[test]
+fn issue180_parse_fk_referenced_table_quoted_identifier_with_dot() {
+    // PR #184 review: a quoted identifier may contain a literal `.`,
+    // and the schema/name split must respect quotes — otherwise the
+    // first dot inside the quoted segment is taken as the boundary
+    // and the parsed pair is nonsensical.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (col) REFERENCES \"weird.schema\".\"t\"(id)"
+        ),
+        Some(("weird.schema".to_string(), "t".to_string()))
+    );
+    // Both halves quoted with embedded dots — the split must still
+    // land on the dot OUTSIDE every quoted segment.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES \"a.b\".\"c.d\"(id)"),
+        Some(("a.b".to_string(), "c.d".to_string()))
+    );
 }
 
 #[tokio::test]
-async fn issue180_set_unlogged_orders_by_fk_dependents_first() {
-    // grandparent ← parent ← child (FK chain). All three flip from
-    // LOGGED to UNLOGGED. PostgreSQL rejects `SET UNLOGGED` on a table
-    // referenced by any LOGGED table, so the dependent (leaf) must be
-    // converted before its referenced parent. Required order:
-    // child → parent → grandparent.
+async fn issue180_set_unlogged_skips_ordering_for_new_fks_added_later() {
+    // PR #184 review (FK-timing): when an FK is brand-new in TO it is
+    // not yet active at the moment `emit_persistence_changes` runs —
+    // `compare_foreign_keys` adds it strictly after. The adjacency
+    // must therefore filter to FKs that exist UNCHANGED in both
+    // FROM and TO. Without that filter, an alphabetical pair would
+    // be over-ordered as if the new FK were already live.
+    //
+    // Setup: child references parent in TO (new FK). FROM has no FK.
+    // Both flip from LOGGED to UNLOGGED.
+    //
+    // With the live-FK-set tightening, the adjacency is empty, so
+    // ordering falls back to alphabetical (deterministic via the
+    // sort_key in the topo sort). This is safe because PG won't see
+    // the FK link until after the SET phase.
     let mut from_dump = Dump::new(DumpConfig::default());
     let mut to_dump = Dump::new(DumpConfig::default());
     from_dump
         .tables
-        .push(issue180_chain_table("grandparent", false, None));
+        .push(issue180_logged_table("test_order", "parent", false, None));
+    // FROM child has no FK to parent — the FK is new in TO.
     from_dump
         .tables
-        .push(issue180_chain_table("parent", false, Some("grandparent")));
-    from_dump
-        .tables
-        .push(issue180_chain_table("child", false, Some("parent")));
+        .push(issue180_logged_table("test_order", "child", false, None));
     to_dump
         .tables
-        .push(issue180_chain_table("grandparent", true, None));
-    to_dump
-        .tables
-        .push(issue180_chain_table("parent", true, Some("grandparent")));
-    to_dump
-        .tables
-        .push(issue180_chain_table("child", true, Some("parent")));
+        .push(issue180_logged_table("test_order", "parent", true, None));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
 
-    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
     comparer.compare_tables().await.unwrap();
     let script = comparer.get_script();
 
-    let pos_child = script
-        .find("alter table test_order.child set unlogged;")
-        .expect("child SET UNLOGGED must be emitted");
-    let pos_parent = script
-        .find("alter table test_order.parent set unlogged;")
-        .expect("parent SET UNLOGGED must be emitted");
-    let pos_grand = script
-        .find("alter table test_order.grandparent set unlogged;")
-        .expect("grandparent SET UNLOGGED must be emitted");
-
-    assert!(
-        pos_child < pos_parent,
-        "child must be SET UNLOGGED before parent (FK leaf first): {}",
-        script
-    );
-    assert!(
-        pos_parent < pos_grand,
-        "parent must be SET UNLOGGED before grandparent (FK leaf first): {}",
-        script
-    );
+    // Both SET UNLOGGED statements must be present; ordering between
+    // them is not constrained by the (not-yet-live) new FK.
+    assert!(script.contains("alter table test_order.child set unlogged;"));
+    assert!(script.contains("alter table test_order.parent set unlogged;"));
 }
 
-#[tokio::test]
-async fn issue180_set_logged_orders_by_fk_roots_first() {
-    // Reverse direction: grandparent ← parent ← child (FK chain), all
-    // UNLOGGED in FROM, LOGGED in TO. PostgreSQL rejects `SET LOGGED`
-    // on a table that references any UNLOGGED table, so the referenced
-    // root must be converted before its dependents. Required order:
-    // grandparent → parent → child.
-    let mut from_dump = Dump::new(DumpConfig::default());
-    let mut to_dump = Dump::new(DumpConfig::default());
-    from_dump
-        .tables
-        .push(issue180_chain_table("grandparent", true, None));
-    from_dump
-        .tables
-        .push(issue180_chain_table("parent", true, Some("grandparent")));
-    from_dump
-        .tables
-        .push(issue180_chain_table("child", true, Some("parent")));
-    to_dump
-        .tables
-        .push(issue180_chain_table("grandparent", false, None));
-    to_dump
-        .tables
-        .push(issue180_chain_table("parent", false, Some("grandparent")));
-    to_dump
-        .tables
-        .push(issue180_chain_table("child", false, Some("parent")));
+#[test]
+fn issue180_sequence_only_persistence_change_uses_hash_diff() {
+    // PR #184 review: `is_only_persistence_change` clones, equalises
+    // `is_unlogged` to FROM, recomputes the hash, and compares.
+    // That keeps the check honest if `Sequence::hash` later starts
+    // covering a new field. This test pins the contract by exercising
+    // both directions: identical-except-persistence returns true; a
+    // hashed field different (here `cache_size`) returns false.
+    use crate::dump::sequence::Sequence;
 
-    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
-    comparer.compare_tables().await.unwrap();
-    let script = comparer.get_script();
-
-    let pos_grand = script
-        .find("alter table test_order.grandparent set logged;")
-        .expect("grandparent SET LOGGED must be emitted");
-    let pos_parent = script
-        .find("alter table test_order.parent set logged;")
-        .expect("parent SET LOGGED must be emitted");
-    let pos_child = script
-        .find("alter table test_order.child set logged;")
-        .expect("child SET LOGGED must be emitted");
-
+    let make = |is_unlogged: bool, cache: i64| {
+        let mut s = Sequence::new(
+            "public".to_string(),
+            "s".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(cache),
+            Some(1),
+            None,
+            None,
+            None,
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    let from = make(false, 1);
+    let to_only_persistence = make(true, 1);
+    let to_persistence_and_cache = make(true, 5);
     assert!(
-        pos_grand < pos_parent,
-        "grandparent must be SET LOGGED before parent (FK root first): {}",
-        script
+        to_only_persistence.is_only_persistence_change(&from),
+        "identical except is_unlogged must be detected as persistence-only"
     );
     assert!(
-        pos_parent < pos_child,
-        "parent must be SET LOGGED before child (FK root first): {}",
-        script
-    );
-}
-
-#[tokio::test]
-async fn issue180_persistence_only_change_skips_owned_sequence_alter() {
-    // A sequence whose owning table flips persistence must NOT emit
-    // its own ALTER SEQUENCE SET LOGGED|UNLOGGED — the table-level
-    // ALTER TABLE propagates to every owned sequence automatically.
-    // When persistence is the *only* diff, the entire ALTER SEQUENCE
-    // block is suppressed (no redundant `start with … increment by …`).
-    let mut from_dump = Dump::new(DumpConfig::default());
-    let mut to_dump = Dump::new(DumpConfig::default());
-
-    let mut from_seq = Sequence::new(
-        "test_order".to_string(),
-        "items_id_seq".to_string(),
-        "postgres".to_string(),
-        "integer".to_string(),
-        Some(1),
-        Some(1),
-        Some(2147483647),
-        Some(1),
-        false,
-        Some(1),
-        Some(1),
-        Some("test_order".to_string()),
-        Some("items".to_string()),
-        Some("id".to_string()),
-    );
-    from_seq.is_unlogged = false;
-    from_seq.hash();
-    let mut to_seq = from_seq.clone();
-    to_seq.is_unlogged = true;
-    to_seq.hash();
-    from_dump.sequences.push(from_seq);
-    to_dump.sequences.push(to_seq);
-
-    // Owning table flips LOGGED → UNLOGGED.
-    from_dump
-        .tables
-        .push(issue180_chain_table("items", false, None));
-    to_dump
-        .tables
-        .push(issue180_chain_table("items", true, None));
-
-    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
-    comparer.compare_sequences().await.unwrap();
-    let script = comparer.get_script();
-
-    assert!(
-        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
-        "owned sequence's SET UNLOGGED is redundant — table propagates: {}",
-        script
-    );
-    assert!(
-        !script.contains("alter sequence test_order.items_id_seq start with"),
-        "no `alter sequence … start with …` either — persistence was the only diff: {}",
-        script
-    );
-}
-
-#[tokio::test]
-async fn issue180_sequence_with_other_changes_omits_persistence_line_only() {
-    // A sequence whose owning table flips persistence AND whose own
-    // parameters also change must still emit an ALTER SEQUENCE for the
-    // parameter diff — but NOT the SET LOGGED|UNLOGGED line, because
-    // the table-level ALTER propagates that change.
-    let mut from_dump = Dump::new(DumpConfig::default());
-    let mut to_dump = Dump::new(DumpConfig::default());
-
-    let mut from_seq = Sequence::new(
-        "test_order".to_string(),
-        "items_id_seq".to_string(),
-        "postgres".to_string(),
-        "integer".to_string(),
-        Some(1),
-        Some(1),
-        Some(2147483647),
-        Some(1),
-        false,
-        Some(1),
-        Some(1),
-        Some("test_order".to_string()),
-        Some("items".to_string()),
-        Some("id".to_string()),
-    );
-    from_seq.is_unlogged = false;
-    from_seq.hash();
-    let mut to_seq = from_seq.clone();
-    to_seq.is_unlogged = true;
-    // Real param diff: cache size change.
-    to_seq.cache_size = Some(50);
-    to_seq.hash();
-    from_dump.sequences.push(from_seq);
-    to_dump.sequences.push(to_seq);
-
-    from_dump
-        .tables
-        .push(issue180_chain_table("items", false, None));
-    to_dump
-        .tables
-        .push(issue180_chain_table("items", true, None));
-
-    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
-    comparer.compare_sequences().await.unwrap();
-    let script = comparer.get_script();
-
-    assert!(
-        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
-        "owning table propagates SET — sequence must NOT emit its own SET: {}",
-        script
-    );
-    assert!(
-        script.contains("cache 50"),
-        "the real (non-persistence) diff must still be emitted: {}",
-        script
-    );
-}
-
-#[tokio::test]
-async fn issue180_sequence_persistence_alone_emits_when_table_unchanged() {
-    // Defensive: if the owning table is *not* flipping persistence,
-    // the sequence's own SET must still be emitted (no propagation
-    // happens). Verifies we don't over-suppress.
-    let mut from_dump = Dump::new(DumpConfig::default());
-    let mut to_dump = Dump::new(DumpConfig::default());
-
-    let mut from_seq = Sequence::new(
-        "test_order".to_string(),
-        "loose_seq".to_string(),
-        "postgres".to_string(),
-        "integer".to_string(),
-        Some(1),
-        Some(1),
-        Some(2147483647),
-        Some(1),
-        false,
-        Some(1),
-        Some(1),
-        // No owning table.
-        None,
-        None,
-        None,
-    );
-    from_seq.is_unlogged = false;
-    from_seq.hash();
-    let mut to_seq = from_seq.clone();
-    to_seq.is_unlogged = true;
-    to_seq.hash();
-    from_dump.sequences.push(from_seq);
-    to_dump.sequences.push(to_seq);
-
-    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
-    comparer.compare_sequences().await.unwrap();
-    let script = comparer.get_script();
-
-    assert!(
-        script.contains("alter sequence test_order.loose_seq set unlogged"),
-        "standalone sequence's SET UNLOGGED must still be emitted: {}",
-        script
+        !to_persistence_and_cache.is_only_persistence_change(&from),
+        "a hashed field difference must block the persistence-only suppression"
     );
 }

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -8914,6 +8914,48 @@ fn issue180_parse_fk_referenced_table_quoted_identifier_with_dot() {
     );
 }
 
+#[test]
+fn issue180_parse_fk_referenced_table_handles_non_ascii_column_names() {
+    // PR #184 follow-up review: `parse_fk_referenced_table` previously
+    // built the case-insensitive haystack via `to_lowercase()`, which
+    // can change byte length for some non-ASCII characters
+    // (e.g. capital Turkish dotted I, `İ`, lowercases to a multi-char
+    // sequence with a different UTF-8 length). The keyword position
+    // came from the lowercased haystack but the slice that produces
+    // the parsed identifier reaches back into `def`, so a
+    // length-changing lowercasing would land mid-codepoint and panic.
+    // `to_ascii_lowercase()` is byte-length-preserving — pin that
+    // contract by parsing FK definitions whose column list contains
+    // identifiers that trip every byte-length-changing lowercase
+    // conversion in common locales.
+    //
+    // Quoted column with capital `İ` (U+0130). With `to_lowercase()`
+    // this produces `i\u{0307}` (3 bytes total); `to_ascii_lowercase`
+    // leaves the 2-byte `İ` alone, so byte offsets line up.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"\u{0130}d\") REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // German sharp S (`ß`, U+00DF). `to_lowercase()` keeps it as `ß`,
+    // but the inverse — uppercase `ẞ` (U+1E9E) lowercasing to `ß` —
+    // is length-preserving in UTF-8 too. Use a Cyrillic lowercase
+    // identifier here just to round out coverage of identifiers whose
+    // bytes lie outside the ASCII range.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"русское_имя\") REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // Same case in the qualified target identifier.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES \"тест\".\"target\"(id)"),
+        Some(("тест".to_string(), "target".to_string()))
+    );
+}
+
 #[tokio::test]
 async fn issue180_set_unlogged_skips_ordering_for_new_fks_added_later() {
     // PR #184 review (FK-timing): when an FK is brand-new in TO it is

--- a/app/src/dump/sequence.rs
+++ b/app/src/dump/sequence.rs
@@ -224,11 +224,51 @@ impl Sequence {
     /// would rewind a live sequence whose current position is already above the new
     /// `start_value`, risking duplicate-key violations.
     pub fn get_alter_script(&self, from: &Sequence) -> String {
+        self.build_alter_script(from, true)
+    }
+
+    /// Same as [`Self::get_alter_script`] but never emits the
+    /// `ALTER SEQUENCE ... SET LOGGED|UNLOGGED` line. The comparer
+    /// uses this when the owning table is itself flipping persistence
+    /// in the same migration: PostgreSQL automatically propagates the
+    /// table's `ALTER TABLE SET LOGGED|UNLOGGED` to every owned
+    /// sequence, so re-emitting the SET on the sequence is redundant
+    /// (issue #180).
+    pub fn get_alter_script_excluding_persistence(&self, from: &Sequence) -> String {
+        self.build_alter_script(from, false)
+    }
+
+    /// True when the only field that differs between `self` (TO) and
+    /// `from` is `is_unlogged`. Used by the comparer to suppress an
+    /// otherwise no-op `ALTER SEQUENCE …` for owned sequences whose
+    /// owning table is flipping persistence (the table's `ALTER TABLE
+    /// SET LOGGED|UNLOGGED` propagates to the sequence on its own —
+    /// re-emitting the full clause list would be cosmetic noise).
+    pub fn is_only_persistence_change(&self, from: &Sequence) -> bool {
+        self.is_unlogged != from.is_unlogged
+            && self.schema == from.schema
+            && self.name == from.name
+            && self.owner == from.owner
+            && self.data_type == from.data_type
+            && self.start_value == from.start_value
+            && self.min_value == from.min_value
+            && self.max_value == from.max_value
+            && self.increment_by == from.increment_by
+            && self.cycle == from.cycle
+            && self.cache_size == from.cache_size
+            && self.is_identity == from.is_identity
+            && self.comment == from.comment
+            && self.owned_by_schema == from.owned_by_schema
+            && self.owned_by_table == from.owned_by_table
+            && self.owned_by_column == from.owned_by_column
+    }
+
+    fn build_alter_script(&self, from: &Sequence, include_persistence: bool) -> String {
         let mut clauses = Vec::new();
 
         // Handle logged/unlogged change
         let mut logging_script = String::new();
-        if self.is_unlogged != from.is_unlogged {
+        if include_persistence && self.is_unlogged != from.is_unlogged {
             if self.is_unlogged {
                 logging_script =
                     format!("alter sequence {}.{} set unlogged;", self.schema, self.name)

--- a/app/src/dump/sequence.rs
+++ b/app/src/dump/sequence.rs
@@ -244,21 +244,32 @@ impl Sequence {
     /// owning table is flipping persistence (the table's `ALTER TABLE
     /// SET LOGGED|UNLOGGED` propagates to the sequence on its own —
     /// re-emitting the full clause list would be cosmetic noise).
+    ///
+    /// Implementation strategy: clone `self`, force its `is_unlogged`
+    /// back to `from`'s value, recompute the hash, and compare. This
+    /// piggy-backs on [`Self::hash`] so any new field added to the
+    /// hash is automatically considered here — there's no field list
+    /// to forget to update. We also explicitly compare the few fields
+    /// that `hash()` deliberately leaves out but `get_alter_script`
+    /// renders (`owned_by_*`); a change there must still block the
+    /// suppression because the table-cascade does NOT propagate
+    /// ownership changes.
     pub fn is_only_persistence_change(&self, from: &Sequence) -> bool {
-        self.is_unlogged != from.is_unlogged
-            && self.schema == from.schema
-            && self.name == from.name
-            && self.owner == from.owner
-            && self.data_type == from.data_type
-            && self.start_value == from.start_value
-            && self.min_value == from.min_value
-            && self.max_value == from.max_value
-            && self.increment_by == from.increment_by
-            && self.cycle == from.cycle
-            && self.cache_size == from.cache_size
-            && self.is_identity == from.is_identity
-            && self.comment == from.comment
-            && self.owned_by_schema == from.owned_by_schema
+        if self.is_unlogged == from.is_unlogged {
+            return false;
+        }
+        // Hash mismatch on the persistence-equalised clone means SOME
+        // hashed field other than `is_unlogged` differs.
+        let mut probe = self.clone();
+        probe.is_unlogged = from.is_unlogged;
+        probe.hash();
+        if probe.hash != from.hash {
+            return false;
+        }
+        // Ownership info is rendered in `get_alter_script` but not
+        // hashed — keep the explicit checks as a belt-and-braces guard
+        // against a behaviour-affecting change being silently dropped.
+        self.owned_by_schema == from.owned_by_schema
             && self.owned_by_table == from.owned_by_table
             && self.owned_by_column == from.owned_by_column
     }

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -1811,21 +1811,18 @@ impl Table {
             ));
         }
 
-        // UNLOGGED / LOGGED change
-        if self.is_unlogged != to_table.is_unlogged {
-            let stmt = if to_table.is_unlogged {
-                format!(
-                    "alter table {}.{} set unlogged;",
-                    to_table.schema, to_table.name
-                )
-            } else {
-                format!(
-                    "alter table {}.{} set logged;",
-                    to_table.schema, to_table.name
-                )
-            };
-            script.append_block(&stmt);
-        }
+        // UNLOGGED / LOGGED change is emitted by the comparer in a
+        // separate FK-ordered phase (see issue #180). Doing it inline
+        // here would interleave SET UNLOGGED/LOGGED statements with the
+        // alphabetical table order PostgreSQL rejects:
+        //   * SET UNLOGGED fails if any LOGGED table references this
+        //     one — referencers (leaves) must be converted first.
+        //   * SET LOGGED   fails if this table references any UNLOGGED
+        //     one — referenced tables (roots) must be converted first.
+        // Both directions therefore need a topological pass that this
+        // per-table function can't perform. The comparer collects
+        // `Self::persistence_change_for(&to_table)` results from every
+        // pair and emits them in the right order at end of compare.
 
         // Storage parameters change
         if self.storage_parameters != to_table.storage_parameters {
@@ -1905,6 +1902,22 @@ impl Table {
     /// Get script for altering the table without triggers (for deferred trigger creation)
     pub fn get_alter_script_without_triggers(&self, to_table: &Table, use_drop: bool) -> String {
         self.build_alter_script(to_table, use_drop, false)
+    }
+
+    /// Returns `Some(target_is_unlogged)` when this table's logging
+    /// status differs from `to_table`. The comparer collects these per
+    /// (FROM, TO) pair and emits the resulting `ALTER TABLE ... SET
+    /// LOGGED|UNLOGGED` statements in FK-topological order (see issue
+    /// #180): inline emission in `build_alter_script` would honour the
+    /// alphabetical table iteration order, which PostgreSQL rejects
+    /// whenever a referencing-table / referenced-table pair flip
+    /// persistence in the same migration.
+    pub fn persistence_change_for(&self, to_table: &Table) -> Option<bool> {
+        if self.is_unlogged != to_table.is_unlogged {
+            Some(to_table.is_unlogged)
+        } else {
+            None
+        }
     }
 
     fn get_trigger_alter_parts(&self, to_table: &Table, use_drop: bool) -> (String, String) {

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -15,6 +15,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 
 ### 1. Schemas
 - **Added**: `new_reporting_schema` in Schema B
+- **Added**: `test_order` (issue #180 FK-ordered SET LOGGED/UNLOGGED) in both schemas — entire chain flips from LOGGED in Schema A to UNLOGGED in Schema B
 - **Unchanged**: `test_schema`, `shared_schema`
 
 ### 2. Extensions
@@ -282,6 +283,7 @@ Grant comparison test using roles `pgc_grant_reader` and `pgc_grant_writer`.
 ### 28. UNLOGGED Tables
 - **Modified**: `test_schema.unlogged_test` — regular (logged) table in FROM; UNLOGGED in TO
 - Verifies `ALTER TABLE SET UNLOGGED` / `SET LOGGED` generation
+- **FK-chain conversion (Issue #180)**: `test_order.grandparent`, `test_order.parent`, `test_order.child` — three LOGGED tables with FK chain `child -> parent -> grandparent` in Schema A; all three UNLOGGED in Schema B. Verifies the comparer emits `SET UNLOGGED` in FK-leaf-first order (`child`, then `parent`, then `grandparent`); the alphabetical order PostgreSQL would otherwise reject with `ERROR: could not change table "grandparent" to unlogged because it references logged table "parent"`. Each table's `serial` PK auto-creates an owned sequence (`*_id_seq`) — these must NOT receive an explicit `ALTER SEQUENCE ... SET UNLOGGED`, since `ALTER TABLE SET UNLOGGED` propagates to owned sequences automatically.
 
 ### 29. Storage Parameters (reloptions)
 - **Modified**: `test_schema.storage_params_test` — `fillfactor=70` in FROM; `fillfactor=90, autovacuum_enabled=false` in TO
@@ -594,7 +596,7 @@ The comparison should detect and generate SQL for:
 - Creating, dropping, and altering extended statistics (kind changes via drop+recreate)
 - Detecting NOT ENFORCED constraint flag changes (PG18+)
 - Handling virtual/stored generated column transitions (PG18+)
-- Detecting UNLOGGED ↔ LOGGED table persistence changes
+- Detecting UNLOGGED ↔ LOGGED table persistence changes, ordering `SET UNLOGGED` / `SET LOGGED` topologically over the FK graph (leaves-first / roots-first respectively) and suppressing redundant `ALTER SEQUENCE ... SET UNLOGGED|LOGGED` on owned sequences whose owning table is flipping in the same migration — PostgreSQL propagates the table change to owned sequences automatically (Issue #180)
 - Detecting storage parameters (reloptions/WITH clause) changes (fillfactor, autovacuum settings, etc.)
 - Detecting REPLICA IDENTITY changes (DEFAULT, NOTHING, FULL)
 - Detecting FORCE ROW LEVEL SECURITY changes

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -1417,3 +1417,43 @@ ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY pol_cascade_items ON test_schema.cascade_items
     USING (test_schema.cascade_compute(value) > 0);
 
+-- =============================================================================
+-- Issue #180 — FK-ordered SET LOGGED/UNLOGGED + redundant owned-sequence ALTER
+-- =============================================================================
+-- FROM has three LOGGED tables connected by a foreign-key chain
+-- (child -> parent -> grandparent). Schema B converts every table in
+-- the chain to UNLOGGED. The migration script must emit
+-- `ALTER TABLE ... SET UNLOGGED` in FK-leaf-first order
+-- (child -> parent -> grandparent); alphabetical order — which the
+-- comparer used before this fix — fails with:
+--   ERROR: could not change table "grandparent" to unlogged because
+--   it references logged table "parent"
+--
+-- The reverse direction (UNLOGGED -> LOGGED) requires the opposite
+-- order (roots first); both directions are exercised by the comparer's
+-- `Comparer::emit_persistence_changes` phase, which sorts each
+-- direction topologically over the FK adjacency derived from
+-- `pg_get_constraintdef`.
+--
+-- The serial PKs auto-create owned sequences. PostgreSQL propagates
+-- the table's `ALTER TABLE SET UNLOGGED` to every owned sequence
+-- automatically, so the comparer must NOT emit an explicit
+-- `ALTER SEQUENCE ... SET UNLOGGED` for them — when the only diff is
+-- `is_unlogged` and the owning table is also flipping, the entire
+-- ALTER SEQUENCE block is suppressed (issue #180).
+CREATE SCHEMA IF NOT EXISTS test_order;
+
+CREATE TABLE test_order.grandparent (
+    id serial PRIMARY KEY
+);
+
+CREATE TABLE test_order.parent (
+    id serial PRIMARY KEY,
+    grandparent_id integer REFERENCES test_order.grandparent(id)
+);
+
+CREATE TABLE test_order.child (
+    id serial PRIMARY KEY,
+    parent_id integer REFERENCES test_order.parent(id)
+);
+

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -1740,3 +1740,34 @@ CREATE INDEX idx_cascade_compute
 ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY pol_cascade_items ON test_schema.cascade_items
     USING (test_schema.cascade_compute(value) > 0);
+
+-- =============================================================================
+-- Issue #180 — FK-ordered SET LOGGED/UNLOGGED + redundant owned-sequence ALTER
+-- =============================================================================
+-- TO mirrors Schema A's FK chain (child -> parent -> grandparent) but
+-- every table is now UNLOGGED. The comparer must emit
+-- `ALTER TABLE ... SET UNLOGGED` in FK-leaf-first order
+-- (child, then parent, then grandparent) — alphabetical order rejects
+-- with:
+--   ERROR: could not change table "grandparent" to unlogged because
+--   it references logged table "parent"
+--
+-- The serial PKs auto-create owned sequences (`*_id_seq`). PostgreSQL
+-- propagates the table's `ALTER TABLE SET UNLOGGED` to every owned
+-- sequence on its own, so no explicit `ALTER SEQUENCE ... SET
+-- UNLOGGED` should appear for those sequences in the migration.
+CREATE SCHEMA IF NOT EXISTS test_order;
+
+CREATE UNLOGGED TABLE test_order.grandparent (
+    id serial PRIMARY KEY
+);
+
+CREATE UNLOGGED TABLE test_order.parent (
+    id serial PRIMARY KEY,
+    grandparent_id integer REFERENCES test_order.grandparent(id)
+);
+
+CREATE UNLOGGED TABLE test_order.child (
+    id serial PRIMARY KEY,
+    parent_id integer REFERENCES test_order.parent(id)
+);


### PR DESCRIPTION
Fixed issue #180: `ALTER TABLE ... SET LOGGED| UNLOGGED` was emitted inline with the per-table alter loop in alphabetical order, which PostgreSQL rejects whenever an FK chain flips persistence in the same migration — `SET UNLOGGED` fails if any LOGGED table references the target, `SET LOGGED` fails if the target references any UNLOGGED one. Moved the emission out of `Table::build_alter_script` and into a dedicated `Comparer::emit_persistence_ changes` phase that runs at the end of `compare_tables`: tables flipping to UNLOGGED are sorted leaves-before-roots (reverse FK topo), tables flipping to LOGGED are sorted roots-before-leaves (forward FK topo), each via `Self::topo_order_within_subset` over an FK adjacency derived from the TO-side constraint definitions (parsed by `Self::parse_fk_ referenced_table`). Owned sequences also get cleaner output: `Sequence::is_only_persistence_ change` lets `compare_sequences` skip the entire `ALTER SEQUENCE` for sequences whose only diff is `is_unlogged` and whose owning table is itself flipping persistence (PostgreSQL propagates the `ALTER TABLE SET LOGGED|UNLOGGED` to every owned sequence automatically, so the explicit emit was redundant), and `Sequence::get_alter_script_ excluding_persistence` strips just the `ALTER SEQUENCE … SET LOGGED|UNLOGGED` line when the sequence has other diffs to emit but the owning table will still propagate the persistence flip.