### PR TITLE
Apply v1.0.20

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,7 +137,7 @@ jobs:
         FROM_USER=postgres
         FROM_PASSWORD=postgres
         FROM_DATABASE=a
-        FROM_SCHEME=test_schema|shared_schema|new_reporting_schema|data
+        FROM_SCHEME=test_schema|shared_schema|new_reporting_schema|data|test_order
         FROM_SSL=false
         FROM_DUMP=/tmp/a.dump
         TO_HOST=127.0.0.1
@@ -145,7 +145,7 @@ jobs:
         TO_USER=postgres
         TO_PASSWORD=postgres
         TO_DATABASE=b
-        TO_SCHEME=test_schema|shared_schema|new_reporting_schema|data
+        TO_SCHEME=test_schema|shared_schema|new_reporting_schema|data|test_order
         TO_SSL=false
         TO_DUMP=/tmp/b.dump
         OUTPUT=/tmp/output.sql

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,30 @@
 2026-05-14      v1.0.20
 
                 Bug fixes:
+                    - Fixed issue #181 (PG18 virtual generated columns):
+                      a STORED ↔ VIRTUAL flip with the same generation
+                      expression produced no script at all, because
+                      `TableColumn::get_alter_script`'s
+                      `generated_changed` predicate only considered
+                      `is_generated` and `generation_expression` and
+                      ignored `generation_type`. Now compares
+                      `effective_generation_type` as well, so the flip
+                      is detected. And a virtual generated column with
+                      a changed expression used to emit
+                      `ALTER COLUMN DROP EXPRESSION` + `ALTER COLUMN
+                      ADD GENERATED ALWAYS AS (...) VIRTUAL`, both of
+                      which PG18 rejects (DROP EXPRESSION is
+                      STORED-only; the ADD GENERATED form has no
+                      VIRTUAL variant). The fix routes every VIRTUAL
+                      participant — flips of `generation_type` in
+                      either direction, and expression changes on a
+                      VIRTUAL column — through the full
+                      `DROP COLUMN` + `ADD COLUMN ... GENERATED ALWAYS
+                      AS (...) VIRTUAL|STORED` round-trip, which is
+                      the only valid migration PG18 accepts. STORED →
+                      STORED expression changes keep the cheaper
+                      in-place `DROP EXPRESSION` + `ADD GENERATED ...
+                      STORED` form.
                     - Fixed issue #180: `ALTER TABLE ... SET LOGGED|
                       UNLOGGED` was emitted inline with the per-table
                       alter loop in alphabetical order, which

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,29 +49,33 @@
                       references the target, `SET LOGGED` fails if the
                       target references any UNLOGGED one. Moved the
                       emission out of `Table::build_alter_script` and
-                      into a dedicated `Comparer::emit_persistence_
-                      changes` phase that runs at the end of
-                      `compare_tables`: tables flipping to UNLOGGED are
-                      sorted leaves-before-roots (reverse FK topo),
-                      tables flipping to LOGGED are sorted
+                      into a dedicated
+                      `Comparer::emit_persistence_changes` phase that
+                      runs at the end of `compare_tables`: tables
+                      flipping to UNLOGGED are sorted
+                      leaves-before-roots (reverse FK topo), tables
+                      flipping to LOGGED are sorted
                       roots-before-leaves (forward FK topo), each via
                       `Self::topo_order_within_subset` over an FK
                       adjacency derived from the TO-side constraint
-                      definitions (parsed by `Self::parse_fk_
-                      referenced_table`). Owned sequences also get
-                      cleaner output: `Sequence::is_only_persistence_
-                      change` lets `compare_sequences` skip the entire
-                      `ALTER SEQUENCE` for sequences whose only diff is
-                      `is_unlogged` and whose owning table is itself
-                      flipping persistence (PostgreSQL propagates the
+                      definitions (parsed by
+                      `Self::parse_fk_referenced_table`). Owned
+                      sequences also get cleaner output:
+                      `Sequence::is_only_persistence_change` lets
+                      `compare_sequences` skip the entire
+                      `ALTER SEQUENCE` for sequences whose only diff
+                      is `is_unlogged` and whose owning table is
+                      itself flipping persistence (PostgreSQL
+                      propagates the
                       `ALTER TABLE SET LOGGED|UNLOGGED` to every owned
                       sequence automatically, so the explicit emit was
-                      redundant), and `Sequence::get_alter_script_
-                      excluding_persistence` strips just the
+                      redundant), and
+                      `Sequence::get_alter_script_excluding_persistence`
+                      strips just the
                       `ALTER SEQUENCE … SET LOGGED|UNLOGGED` line when
                       the sequence has other diffs to emit but the
-                      owning table will still propagate the persistence
-                      flip.
+                      owning table will still propagate the
+                      persistence flip.
                     - Fixed issue #179: when a routine was dropped or
                       its return type / arguments / argument defaults
                       changed, `DROP FUNCTION ... CASCADE` silently
@@ -114,8 +118,16 @@
                       constraints attached to a still-present column).
                       `Routine::hash()` now includes
                       `arguments_defaults` so a defaults-only change
-                      actually triggers DROP+CREATE (PostgreSQL has no
-                      in-place `ALTER FUNCTION` for default values).
+                      is *detected*. The migration is then emitted
+                      via `CREATE OR REPLACE FUNCTION` — defaults can
+                      be updated for the same identity signature and
+                      return type without a DROP+CREATE — so
+                      `emit_routine_diff` and Phase 7 explicitly
+                      exclude defaults-only diffs from the
+                      DROP-CASCADE path. The earlier draft of this
+                      entry described defaults as a DROP+CREATE
+                      requirement; that wording was wrong (PR #187
+                      review).
                       Note: a v1.0.19 dump compared against a v1.0.20
                       dump may flag every routine carrying defaults as
                       changed even when the body is identical; rebuild

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,55 @@
+2026-05-14      v1.0.20
+
+                Bug fixes:
+                    - Fixed issue #179: when a routine was dropped or
+                      its return type / arguments / argument defaults
+                      changed, `DROP FUNCTION ... CASCADE` silently
+                      removed every dependent linked through
+                      `pg_depend` — functional indexes, CHECK
+                      constraints, generated columns, column DEFAULTs,
+                      and RLS policies — and the comparer never
+                      re-emitted them, leaving the database missing
+                      those objects until a second `pgc compare` run.
+                      Added Phase 7 to
+                      `Comparer::compare_routines_and_views`: after the
+                      affected functions are recreated, restore each
+                      cascaded dependent from its TO-side definition.
+                      Generated columns and indexes use non-destructive
+                      `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT
+                      EXISTS`; constraints, policies, and DEFAULTs use
+                      idempotent `drop ... if exists` + create or
+                      `alter column set default`. The phase honours
+                      multiple safety gates: partition-child rules
+                      (skip inherited constraints, partition-inherited
+                      indexes, and all structural column changes —
+                      truly-local child constraints still re-emit);
+                      qualified and unqualified detection (deparsers
+                      drop the schema qualifier when the function is in
+                      `search_path`, both forms must require a `(` call
+                      gate so `ON schema.table` / `nextval(... ::
+                      regclass)` don't false-positive); UTF-8 boundary
+                      walking via `match_indices` for non-ASCII
+                      identifiers (`"русское_имя"`); quote-stripped
+                      affected-routine names so `quote_ident`-wrapped
+                      `"MyFunc"` matches the deparsed `myfunc(`; and a
+                      TO-side reference check so dependents already
+                      rewritten by `compare_tables()` are left alone
+                      (the broken `pg_depend` link means CASCADE leaves
+                      them intact, and the IF NOT EXISTS forms make the
+                      false-positive case a runtime no-op rather than a
+                      destructive drop — overloaded routines collapse
+                      together in the text matcher and would otherwise
+                      cascade-destroy unrelated indexes / FKs /
+                      constraints attached to a still-present column).
+                      `Routine::hash()` now includes
+                      `arguments_defaults` so a defaults-only change
+                      actually triggers DROP+CREATE (PostgreSQL has no
+                      in-place `ALTER FUNCTION` for default values).
+                      Note: a v1.0.19 dump compared against a v1.0.20
+                      dump may flag every routine carrying defaults as
+                      changed even when the body is identical; rebuild
+                      the FROM dump under v1.0.20 to suppress the noise.
+
 2026-05-03      v1.0.19
 
                 Bug fixes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,21 @@
 2026-05-14      v1.0.20
 
                 Bug fixes:
+                    - Fixed issue #182 (PG18 NOT ENFORCED CHECK
+                      constraints): `TableConstraint::get_script` was
+                      appending its own ` not enforced ` clause even
+                      when the deparser-supplied `definition` already
+                      ended in `NOT ENFORCED`. PG18+
+                      `pg_get_constraintdef()` includes the keyword
+                      when the constraint is non-enforced, so the
+                      generated SQL came out as `… not enforced not
+                      enforced ;`. PostgreSQL accepts the duplicate
+                      idempotently so it never failed at runtime, but
+                      the output was wrong. The fix only appends the
+                      keyword when the `clause` (case-insensitively)
+                      doesn't already contain it; older-PG dumps and
+                      the keyword-less `parts.join`-built path keep
+                      working.
                     - Fixed issue #181 (PG18 virtual generated columns):
                       a STORED ↔ VIRTUAL flip with the same generation
                       expression produced no script at all, because

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,38 @@
 2026-05-14      v1.0.20
 
                 Bug fixes:
+                    - Fixed issue #180: `ALTER TABLE ... SET LOGGED|
+                      UNLOGGED` was emitted inline with the per-table
+                      alter loop in alphabetical order, which
+                      PostgreSQL rejects whenever an FK chain flips
+                      persistence in the same migration —
+                      `SET UNLOGGED` fails if any LOGGED table
+                      references the target, `SET LOGGED` fails if the
+                      target references any UNLOGGED one. Moved the
+                      emission out of `Table::build_alter_script` and
+                      into a dedicated `Comparer::emit_persistence_
+                      changes` phase that runs at the end of
+                      `compare_tables`: tables flipping to UNLOGGED are
+                      sorted leaves-before-roots (reverse FK topo),
+                      tables flipping to LOGGED are sorted
+                      roots-before-leaves (forward FK topo), each via
+                      `Self::topo_order_within_subset` over an FK
+                      adjacency derived from the TO-side constraint
+                      definitions (parsed by `Self::parse_fk_
+                      referenced_table`). Owned sequences also get
+                      cleaner output: `Sequence::is_only_persistence_
+                      change` lets `compare_sequences` skip the entire
+                      `ALTER SEQUENCE` for sequences whose only diff is
+                      `is_unlogged` and whose owning table is itself
+                      flipping persistence (PostgreSQL propagates the
+                      `ALTER TABLE SET LOGGED|UNLOGGED` to every owned
+                      sequence automatically, so the explicit emit was
+                      redundant), and `Sequence::get_alter_script_
+                      excluding_persistence` strips just the
+                      `ALTER SEQUENCE … SET LOGGED|UNLOGGED` line when
+                      the sequence has other diffs to emit but the
+                      owning table will still propagate the persistence
+                      flip.
                     - Fixed issue #179: when a routine was dropped or
                       its return type / arguments / argument defaults
                       changed, `DROP FUNCTION ... CASCADE` silently

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -1146,7 +1146,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgc"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "chrono",
  "clap",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgc"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2024"
 license = "MIT"
 authors = ["nettrash <nettrash@nettrash.me>"]

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1,5 +1,9 @@
 use crate::config::grants_mode::GrantsMode;
 use crate::dump::acl;
+use crate::dump::table_column::TableColumn;
+use crate::dump::table_constraint::TableConstraint;
+use crate::dump::table_index::TableIndex;
+use crate::dump::table_policy::TablePolicy;
 use crate::dump::{core::Dump, routine::Routine, table::Table, view::View};
 use crate::utils::string_extensions::StringExt;
 use std::{
@@ -3185,9 +3189,533 @@ impl Comparer {
             }
         }
 
+        // ──────────────────────────────────────────────────────────
+        // Phase 7 – Recreate dependents silently dropped by CASCADE
+        // ──────────────────────────────────────────────────────────
+        // When a routine is fully dropped, or its return type / argument
+        // list / argument defaults change (each forces DROP+CREATE
+        // because PostgreSQL has no in-place ALTER for those), PGC emits
+        // `DROP ... CASCADE` and PostgreSQL removes every object whose
+        // `pg_depend` entry points at that function: functional indexes,
+        // CHECK constraints, generated columns, column DEFAULT
+        // expressions and RLS policies. The rest of the comparer never
+        // re-emits those dependents because they were unchanged between
+        // FROM and TO. See issue #179.
+        self.recreate_routine_dependents();
+
         self.script
             .append_block("\n/* ---> Routines & Views: End section --------------- */");
         Ok(())
+    }
+
+    /// Re-emit objects that PostgreSQL silently dropped via
+    /// `DROP FUNCTION ... CASCADE` so they are present in the database
+    /// after the migration applies. Targets functional indexes, CHECK
+    /// constraints, generated columns, column DEFAULT expressions and
+    /// RLS policies that reference any routine being dropped+recreated
+    /// or fully dropped. Detection is text-based against the FROM-side
+    /// definition; the recreated form comes from TO so any reshape of
+    /// the dependent (e.g. a column type change) is preserved. Issued
+    /// statements are idempotent (`drop ... if exists` followed by the
+    /// CREATE) so they are safe even when other diff phases also
+    /// emitted the object.
+    fn recreate_routine_dependents(&mut self) {
+        // Collect (schema_lc, name_lc) for every routine whose drop will
+        // CASCADE: routines absent from TO, plus routines whose signature
+        // (return type, args, default args) changed — the same condition
+        // that drives the DROP+CREATE branch in `emit_routine_diff`.
+        let to_routines_by_full_id: HashMap<(&str, &str, &str), &Routine> = self
+            .to
+            .routines
+            .iter()
+            .map(|r| {
+                (
+                    (r.schema.as_str(), r.name.as_str(), r.arguments.as_str()),
+                    r,
+                )
+            })
+            .collect();
+
+        let mut affected: HashSet<(String, String)> = HashSet::new();
+        for from_routine in &self.from.routines {
+            let key = (
+                from_routine.schema.as_str(),
+                from_routine.name.as_str(),
+                from_routine.arguments.as_str(),
+            );
+            let cascaded = match to_routines_by_full_id.get(&key) {
+                None => true,
+                Some(to_routine) => {
+                    from_routine.hash.is_some()
+                        && to_routine.hash.is_some()
+                        && Self::hashes_differ(&from_routine.hash, &to_routine.hash)
+                        && (from_routine.return_type != to_routine.return_type
+                            || from_routine.arguments != to_routine.arguments
+                            || from_routine.arguments_defaults != to_routine.arguments_defaults)
+                }
+            };
+            if cascaded {
+                // The dump query wraps `nspname` / `proname` with
+                // `quote_ident` (see `dump/core.rs`), so a routine named
+                // `MyFunc` lands here as `"MyFunc"`. Strip the quotes
+                // before storing — both matchers below operate on
+                // quote-stripped haystacks (`unquoted` half of
+                // `prelower_pair`), and the qualified matcher already
+                // re-strips its pattern internally, so a quote-free
+                // needle works for both forms.
+                affected.insert((
+                    from_routine.schema.to_lowercase().replace('"', ""),
+                    from_routine.name.to_lowercase().replace('"', ""),
+                ));
+            }
+        }
+
+        if affected.is_empty() {
+            return;
+        }
+
+        let to_table_by_id: HashMap<(&str, &str), &Table> = self
+            .to
+            .tables
+            .iter()
+            .map(|t| ((t.schema.as_str(), t.name.as_str()), t))
+            .collect();
+
+        let mut emitted_keys: HashSet<String> = HashSet::new();
+        let mut recreate: String = String::new();
+
+        for from_table in &self.from.tables {
+            // If the table is gone in TO it is being dropped — there is
+            // no post-migration object to restore the dependents onto.
+            let Some(to_table) =
+                to_table_by_id.get(&(from_table.schema.as_str(), from_table.name.as_str()))
+            else {
+                continue;
+            };
+
+            // Mirror Table::diff's partition-child safeguards. When both
+            // FROM and TO are partition children, structural changes to
+            // inherited columns/constraints/indexes belong to the
+            // parent's recreate path: PostgreSQL forbids `ALTER TABLE
+            // child DROP COLUMN` for inherited columns, refuses direct
+            // ALTER on inherited constraints (`coninhcount > 0`), and
+            // partition-inherited indexes are managed by attaching to
+            // the parent's index. Re-emitting them on the child would
+            // produce a script PostgreSQL rejects.
+            let is_target_partition =
+                from_table.partition_of.is_some() && to_table.partition_of.is_some();
+
+            // Each scan below requires BOTH FROM and TO to reference an
+            // affected routine before re-emitting:
+            //
+            // * FROM-reference is necessary to know the dependent
+            //   *had* a `pg_depend` link to the function before the
+            //   migration began — otherwise CASCADE would never have
+            //   touched it in the first place.
+            //
+            // * TO-reference is necessary because `compare_tables()`
+            //   runs *before* `compare_routines_and_views()` and may
+            //   already have rewritten the dependent to its TO-side
+            //   form, breaking the dependency. Once the link is gone,
+            //   `DROP FUNCTION ... CASCADE` leaves the object alone —
+            //   re-emitting a recreate would be redundant for
+            //   constraints/indexes/policies and *destructive* for
+            //   generated columns: `DROP COLUMN IF EXISTS` cascades to
+            //   indexes, constraints, and FKs that reference the
+            //   column, none of which Phase 7 restores.
+            //
+            // CHECK and EXCLUDE constraints can reference functions;
+            // FKs and PKs cannot — skip them to avoid spurious matches
+            // in their textual `definition` (e.g. a referenced table
+            // named similarly to a routine).
+            for constraint in &from_table.constraints {
+                let is_check = constraint.constraint_type.eq_ignore_ascii_case("check")
+                    || constraint.constraint_type.eq_ignore_ascii_case("exclude");
+                if !is_check {
+                    continue;
+                }
+                let Some(def) = &constraint.definition else {
+                    continue;
+                };
+                if !Self::definition_references_any(def, &affected) {
+                    continue;
+                }
+                let Some(to_constraint) = to_table
+                    .constraints
+                    .iter()
+                    .find(|tc| tc.name == constraint.name)
+                else {
+                    continue;
+                };
+                // On partition children, inherited constraints
+                // (coninhcount > 0) propagate from the parent and must
+                // not be re-emitted locally.
+                if is_target_partition && to_constraint.coninhcount > 0 {
+                    continue;
+                }
+                // TO-side gate: skip when the TO definition no longer
+                // references the affected routine — `compare_tables`
+                // has rewritten the constraint, the new form has no
+                // pg_depend link to the function, CASCADE will leave
+                // it intact, and re-emitting would be wasted work.
+                let to_def_refs = to_constraint
+                    .definition
+                    .as_deref()
+                    .map(|d| Self::definition_references_any(d, &affected))
+                    .unwrap_or(false);
+                if !to_def_refs {
+                    continue;
+                }
+                let key = format!(
+                    "constraint:{}.{}.{}",
+                    to_constraint.schema, to_constraint.table_name, to_constraint.name
+                );
+                if !emitted_keys.insert(key) {
+                    continue;
+                }
+                Self::emit_dependent_recreate(
+                    &mut recreate,
+                    self.use_drop,
+                    &constraint_recreate_block(to_constraint),
+                );
+            }
+
+            for index in &from_table.indexes {
+                // Partition-inherited indexes are recreated via the
+                // parent — a redundant CREATE INDEX on the child would
+                // collide with the inherited index name.
+                if index.is_partition_index {
+                    continue;
+                }
+                if !Self::definition_references_any(&index.indexdef, &affected) {
+                    continue;
+                }
+                let Some(to_index) = to_table.indexes.iter().find(|ti| ti.name == index.name)
+                else {
+                    continue;
+                };
+                if to_index.is_partition_index {
+                    continue;
+                }
+                // TO-side gate: see the constraint scan above.
+                if !Self::definition_references_any(&to_index.indexdef, &affected) {
+                    continue;
+                }
+                let key = format!("index:{}.{}", to_index.schema, to_index.name);
+                if !emitted_keys.insert(key) {
+                    continue;
+                }
+                Self::emit_dependent_recreate(
+                    &mut recreate,
+                    self.use_drop,
+                    &index_recreate_block(to_index),
+                );
+            }
+
+            // Structural column changes (ADD / DROP / type) are forbidden
+            // on partition children — the parent owns the column shape.
+            // Skip the whole column scan in that case; the parent's
+            // recreate (handled when we iterate the parent table) will
+            // re-add the dependent.
+            if !is_target_partition {
+                for column in &from_table.columns {
+                    let default_referenced = column
+                        .column_default
+                        .as_deref()
+                        .map(|d| Self::definition_references_any(d, &affected))
+                        .unwrap_or(false);
+                    let generation_referenced = column.is_generated.eq_ignore_ascii_case("ALWAYS")
+                        && column
+                            .generation_expression
+                            .as_deref()
+                            .map(|e| Self::definition_references_any(e, &affected))
+                            .unwrap_or(false);
+
+                    if !default_referenced && !generation_referenced {
+                        continue;
+                    }
+                    let Some(to_column) = to_table.columns.iter().find(|tc| tc.name == column.name)
+                    else {
+                        continue;
+                    };
+
+                    if generation_referenced {
+                        // TO-side gate: only `DROP COLUMN IF EXISTS` +
+                        // re-add the column when TO is *still* a
+                        // generated column whose expression references
+                        // the affected routine. If TO has dropped the
+                        // generation expression or rewritten it to no
+                        // longer reference the function, the column
+                        // survives CASCADE intact and dropping it here
+                        // would cascade-destroy any indexes / FKs /
+                        // constraints attached to it — none of which
+                        // Phase 7 knows how to restore.
+                        let to_generation_refs =
+                            to_column.is_generated.eq_ignore_ascii_case("ALWAYS")
+                                && to_column
+                                    .generation_expression
+                                    .as_deref()
+                                    .map(|e| Self::definition_references_any(e, &affected))
+                                    .unwrap_or(false);
+                        if !to_generation_refs {
+                            continue;
+                        }
+                        let key = format!(
+                            "column-generated:{}.{}.{}",
+                            to_column.schema, to_column.table, to_column.name
+                        );
+                        if emitted_keys.insert(key) {
+                            Self::emit_dependent_recreate(
+                                &mut recreate,
+                                self.use_drop,
+                                &column_recreate_block(to_column),
+                            );
+                        }
+                    } else if default_referenced && let Some(default) = &to_column.column_default {
+                        // TO-side gate: only re-set the DEFAULT when
+                        // TO's default itself still references the
+                        // affected routine. If TO has switched to a
+                        // function-free default (or no default), the
+                        // CASCADE leaves the column alone and
+                        // `compare_tables` already emitted the right
+                        // ALTER COLUMN SET DEFAULT.
+                        if !Self::definition_references_any(default, &affected) {
+                            continue;
+                        }
+                        let key = format!(
+                            "column-default:{}.{}.{}",
+                            to_column.schema, to_column.table, to_column.name
+                        );
+                        if emitted_keys.insert(key) {
+                            let stmt = format!(
+                                "alter table {}.{} alter column {} set default {};",
+                                to_column.schema, to_column.table, to_column.name, default
+                            )
+                            .with_empty_lines();
+                            Self::emit_dependent_recreate(&mut recreate, self.use_drop, &stmt);
+                        }
+                    }
+                }
+            }
+
+            // RLS policies are not inherited via PARTITION OF — each
+            // partition has its own — so no partition-child skip applies.
+            for policy in &from_table.policies {
+                let referenced = policy
+                    .using_clause
+                    .as_deref()
+                    .map(|c| Self::definition_references_any(c, &affected))
+                    .unwrap_or(false)
+                    || policy
+                        .check_clause
+                        .as_deref()
+                        .map(|c| Self::definition_references_any(c, &affected))
+                        .unwrap_or(false);
+                if !referenced {
+                    continue;
+                }
+                let Some(to_policy) = to_table.policies.iter().find(|tp| tp.name == policy.name)
+                else {
+                    continue;
+                };
+                // TO-side gate: same rationale as constraints/indexes.
+                let to_policy_refs = to_policy
+                    .using_clause
+                    .as_deref()
+                    .map(|c| Self::definition_references_any(c, &affected))
+                    .unwrap_or(false)
+                    || to_policy
+                        .check_clause
+                        .as_deref()
+                        .map(|c| Self::definition_references_any(c, &affected))
+                        .unwrap_or(false);
+                if !to_policy_refs {
+                    continue;
+                }
+                let key = format!(
+                    "policy:{}.{}.{}",
+                    to_policy.schema, to_policy.table, to_policy.name
+                );
+                if !emitted_keys.insert(key) {
+                    continue;
+                }
+                Self::emit_dependent_recreate(
+                    &mut recreate,
+                    self.use_drop,
+                    &policy_recreate_block(to_policy),
+                );
+            }
+        }
+
+        if !recreate.is_empty() {
+            self.script
+                .append_block("\n/* ---> Recreate dependents dropped by CASCADE: Start ---- */");
+            self.script.push_str(&recreate);
+            self.script
+                .append_block("/* ---> Recreate dependents dropped by CASCADE: End ------ */");
+        }
+    }
+
+    /// True when `definition` textually references any `(schema, name)` in
+    /// `routines`. Tries the qualified `schema.name` form first, then
+    /// falls back to an *unqualified* function-call match (`name(`):
+    /// PostgreSQL's deparsers (`pg_get_constraintdef`, `pg_get_indexdef`,
+    /// `pg_get_expr`) drop the schema qualifier whenever the function is
+    /// reachable via the active `search_path` — typical for `public` —
+    /// so dependents like `CHECK (compute(value) > 0)` would otherwise
+    /// be missed and the CASCADE drift left unfixed.
+    ///
+    /// The unqualified pass requires `(` (after optional whitespace) so
+    /// it only matches function-call positions: identifiers used as
+    /// column references, type names, or string-literal contents do not
+    /// trigger a false positive.
+    fn definition_references_any(definition: &str, routines: &HashSet<(String, String)>) -> bool {
+        let (lower, unquoted) = Self::prelower_pair(definition);
+        routines.iter().any(|(schema, name)| {
+            // Both passes require a function-call context (`name(` after
+            // optional whitespace). The qualified pass inherits this gate
+            // so a routine name that collides with another object kind
+            // in the same schema (table, sequence, view, …) does not
+            // trip Phase 7 — `pg_get_indexdef` emits `ON schema.table`,
+            // `pg_get_expr` emits `nextval('schema.seq'::regclass)`,
+            // etc., and those non-call references must not look like
+            // CASCADE-affected dependents.
+            Self::text_references_qualified_call(&lower, &unquoted, schema, name)
+                || Self::text_references_unqualified_call(&unquoted, name)
+        })
+    }
+
+    /// Like [`Self::text_references_qualified_name_pre`] but additionally
+    /// requires the `schema.name` reference to be a function call:
+    /// followed (after optional ASCII whitespace) by `(`. Phase 7 uses
+    /// this stricter form so a routine sharing its name with another
+    /// object kind in the same schema (table, sequence, view) does not
+    /// false-positive on the deparsed `ON schema.table` of a CREATE
+    /// INDEX or the `'schema.seq'::regclass` of a `nextval` default.
+    /// The looser, call-context-free
+    /// [`Self::text_references_qualified_name_pre`] is kept for the
+    /// inter-routine dependency scan (which filters non-routine matches
+    /// by identity afterwards) and other call-sites where a non-call
+    /// reference is still meaningful.
+    fn text_references_qualified_call(
+        lowered: &str,
+        unquoted_lowered: &str,
+        schema_lc: &str,
+        name_lc: &str,
+    ) -> bool {
+        let mut pattern = String::with_capacity(schema_lc.len() + 1 + name_lc.len());
+        pattern.push_str(schema_lc);
+        pattern.push('.');
+        pattern.push_str(name_lc);
+        if Self::has_whole_qualified_call(lowered, &pattern) {
+            return true;
+        }
+        let unquoted_pattern: String = if pattern.contains('"') {
+            pattern.chars().filter(|c| *c != '"').collect()
+        } else {
+            pattern
+        };
+        Self::has_whole_qualified_call(unquoted_lowered, &unquoted_pattern)
+    }
+
+    /// Identifier-boundary delimited match for `qualified` plus a call
+    /// gate (optional whitespace then `(`). Mirrors
+    /// [`Self::has_whole_qualified_name`] for boundary semantics; the
+    /// extra gate makes it safe to feed deparsed DDL that may contain
+    /// `schema.name` references in non-call positions.
+    fn has_whole_qualified_call(text: &str, qualified: &str) -> bool {
+        let bytes = text.as_bytes();
+        for (idx, _) in text.match_indices(qualified) {
+            if idx > 0 {
+                let before = bytes[idx - 1];
+                if before.is_ascii_alphanumeric() || before == b'_' {
+                    continue;
+                }
+            }
+            let end = idx + qualified.len();
+            if end < bytes.len() {
+                let after = bytes[end];
+                if after.is_ascii_alphanumeric() || after == b'_' || after == b'.' {
+                    continue;
+                }
+            }
+            let mut j = end;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'(' {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// True when `text` contains `name` as a function call: a whole
+    /// identifier (delimited on the left by a non-identifier, non-dot
+    /// character, on the right by a non-identifier character) followed
+    /// — possibly across whitespace — by `(`. The left-side dot
+    /// exclusion ensures `schema.name(` is left to the qualified
+    /// matcher; the right-side identifier check stops `compute_v2(`
+    /// from matching when `name = "compute"`. `text` and `name` must
+    /// already be lowercased and quote-stripped (use the `unquoted`
+    /// half of [`Self::prelower_pair`]).
+    fn text_references_unqualified_call(text: &str, name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+        // Iterate via `match_indices`, which yields byte offsets that are
+        // guaranteed UTF-8 char boundaries. The previous loop used
+        // `text[start..]` with `start = i + 1`, which panics when `name`
+        // contains non-ASCII bytes (PostgreSQL allows Unicode
+        // identifiers like `"русское_имя"`): `i + 1` lands inside a
+        // multi-byte codepoint and the next slice fails. The boundary
+        // checks below are pure byte comparisons against ASCII, so a
+        // non-ASCII neighbour byte simply fails every `is_ascii_*` test
+        // — that's the desired behaviour, since the call gate further
+        // down requires `(` (after optional ASCII whitespace) and any
+        // non-paren byte exits without matching.
+        let bytes = text.as_bytes();
+        let name_len = name.len();
+        for (i, _) in text.match_indices(name) {
+            if i > 0 {
+                let before = bytes[i - 1];
+                if before.is_ascii_alphanumeric() || before == b'_' || before == b'.' {
+                    continue;
+                }
+            }
+            let end = i + name_len;
+            if end < bytes.len() {
+                let after = bytes[end];
+                if after.is_ascii_alphanumeric() || after == b'_' {
+                    continue;
+                }
+            }
+            let mut j = end;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'(' {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Append a recreate block (drop-if-exists + create) to `out`. When
+    /// `use_drop` is false every line is line-prefixed with `-- ` so the
+    /// SQL is left in for review but won't execute, mirroring
+    /// [`Comparer::emit_drop`].
+    fn emit_dependent_recreate(out: &mut String, use_drop: bool, block: &str) {
+        if use_drop {
+            out.push_str(block);
+        } else {
+            out.push_str(
+                &block
+                    .lines()
+                    .map(|l| format!("-- {}\n", l))
+                    .collect::<String>(),
+            );
+        }
     }
 
     // Compare grants (privileges) for all objects
@@ -3727,6 +4255,82 @@ impl Comparer {
             .append_block("\n/* ---> Grants: End section --------------- */");
         Ok(())
     }
+}
+
+/// `drop constraint if exists` + `add constraint` block from the TO-side
+/// constraint, used to restore a CHECK/EXCLUDE constraint that PostgreSQL
+/// removed when CASCADE-dropping a referenced function.
+fn constraint_recreate_block(constraint: &TableConstraint) -> String {
+    let mut block = format!(
+        "alter table {}.{} drop constraint if exists {};",
+        constraint.schema, constraint.table_name, constraint.name
+    )
+    .with_empty_lines();
+    block.push_str(&constraint.get_script());
+    block
+}
+
+/// `CREATE INDEX IF NOT EXISTS` block built from the TO-side index.
+/// We deliberately *do not* `DROP INDEX` first: Phase 7's text-based
+/// matching cannot tell which overload of an `(schema, name)` routine
+/// a dependent actually called, and the TO-side gate cannot detect
+/// that case either, so the matcher may false-positive on an index
+/// that PostgreSQL never actually CASCADE-dropped. An unconditional
+/// drop in that case would silently invalidate a perfectly good index.
+/// `IF NOT EXISTS` makes the recreate a no-op when the index survived
+/// CASCADE and a real create when it did not.
+fn index_recreate_block(index: &TableIndex) -> String {
+    inject_if_not_exists_into_create_index(&index.get_script())
+}
+
+/// `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` block — used to restore a
+/// generated column that PostgreSQL removed when CASCADE-dropping a
+/// referenced function. Crucially we do NOT emit `DROP COLUMN IF
+/// EXISTS` first: that would cascade-destroy every index, FK, and
+/// CHECK constraint attached to the column, and Phase 7 has no way to
+/// restore those secondary dependents. Because Phase 7's affected-set
+/// keys on `(schema, name)` only and overloaded routines collapse
+/// together, the matcher can false-positive on a column referencing a
+/// completely unrelated overload that survived CASCADE — using
+/// `IF NOT EXISTS` makes that case a no-op rather than a destructive
+/// drop, and still does the right thing when the column was actually
+/// removed.
+fn column_recreate_block(column: &TableColumn) -> String {
+    inject_if_not_exists_into_add_column(&column.get_add_script())
+}
+
+/// Rewrites `CREATE [UNIQUE] INDEX <name>` to
+/// `CREATE [UNIQUE] INDEX IF NOT EXISTS <name>`. PostgreSQL's
+/// `pg_get_indexdef` always uses uppercase keywords, so a literal
+/// prefix match suffices; if neither prefix is present the script is
+/// returned unchanged rather than corrupted.
+fn inject_if_not_exists_into_create_index(script: &str) -> String {
+    if let Some(rest) = script.strip_prefix("CREATE UNIQUE INDEX ") {
+        return format!("CREATE UNIQUE INDEX IF NOT EXISTS {}", rest);
+    }
+    if let Some(rest) = script.strip_prefix("CREATE INDEX ") {
+        return format!("CREATE INDEX IF NOT EXISTS {}", rest);
+    }
+    script.to_string()
+}
+
+/// Rewrites the `add column ` clause produced by `TableColumn::get_add_script`
+/// into `add column if not exists `. The clause is generated by us in
+/// known lowercase form, so a single `replacen` against the first hit
+/// is safe and unambiguous.
+fn inject_if_not_exists_into_add_column(script: &str) -> String {
+    script.replacen("add column ", "add column if not exists ", 1)
+}
+
+/// `drop policy if exists` + `create policy` block from the TO-side policy.
+fn policy_recreate_block(policy: &TablePolicy) -> String {
+    let mut block = format!(
+        "drop policy if exists {} on {}.{};",
+        policy.name, policy.schema, policy.table
+    )
+    .with_empty_lines();
+    block.push_str(&policy.get_script());
+    block
 }
 
 #[cfg(test)]

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -241,9 +241,18 @@ impl Comparer {
             }
 
             if Self::hashes_differ(&from_routine.hash, &routine.hash) {
+                // PR #187 review (C10/C11): only return-type and
+                // identity-argument changes require DROP+CREATE in
+                // PostgreSQL. Default-argument values can be updated
+                // by `CREATE OR REPLACE FUNCTION` for the same
+                // identity signature, so a defaults-only diff (now
+                // detected because the hash includes
+                // `arguments_defaults`) must NOT trigger the
+                // CASCADE-drop path; the routine's own
+                // `get_script()` already emits a `CREATE OR REPLACE`
+                // form that covers the change non-destructively.
                 if from_routine.return_type != routine.return_type
                     || from_routine.arguments != routine.arguments
-                    || from_routine.arguments_defaults != routine.arguments_defaults
                 {
                     Self::emit_drop(script, use_drop, &from_routine.get_drop_script());
                 }
@@ -1896,12 +1905,20 @@ impl Comparer {
         // Index every TO table once; the FK adjacency below and the
         // subset orderings refer to tables by their position in
         // `self.to.tables` to avoid borrow-tied pointer identity.
-        let to_index_by_key: HashMap<(&str, &str), usize> = self
+        // Quote-stripped lookup so FK targets parsed by
+        // `parse_fk_referenced_table` (which strips the surrounding
+        // quotes from a quoted identifier like `"MyTable"`) match the
+        // table-side keys without requiring callers to know the
+        // dump-time quoting form. PR #187 review (C2): without this
+        // normalisation, mixed-case FK chains stored as `"Schema"."T"`
+        // would fall back to alphabetical SET ordering and fail.
+        let strip_quotes = |s: &str| -> String { s.replace('"', "") };
+        let to_index_by_key: HashMap<(String, String), usize> = self
             .to
             .tables
             .iter()
             .enumerate()
-            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .map(|(i, t)| ((strip_quotes(&t.schema), strip_quotes(&t.name)), i))
             .collect();
 
         // Partition into the two flip directions; tables newly created
@@ -1950,12 +1967,23 @@ impl Comparer {
                 // adds it later. A modified FK was dropped in the
                 // per-table ALTER loop and is also absent here. Both
                 // get filtered out.
+                // PR #187 review (C13): an FK is also live during the
+                // SET phase when its sole change between FROM and TO
+                // is one of the in-place-alterable knobs
+                // (deferrability / enforced / no-inherit / comment).
+                // `compare_tables` does NOT drop those — they get
+                // ALTERed in `compare_foreign_keys` later — so the
+                // FK constraint is still active when the persistence
+                // flip runs. Filtering only on byte-identical
+                // definitions would miss them. Use the definitive
+                // alterability check from `TableConstraint`.
                 let live = from_table
                     .map(|ft| {
                         ft.constraints.iter().any(|fc| {
                             fc.name == c.name
                                 && fc.constraint_type.eq_ignore_ascii_case("foreign key")
-                                && fc.definition.as_deref() == c.definition.as_deref()
+                                && (fc.definition.as_deref() == c.definition.as_deref()
+                                    || fc.can_be_altered_to(c))
                         })
                     })
                     .unwrap_or(false);
@@ -1963,7 +1991,7 @@ impl Comparer {
                     continue;
                 }
                 if let Some((schema, name)) = Self::parse_fk_referenced_table(def)
-                    && let Some(&j) = to_index_by_key.get(&(schema.as_str(), name.as_str()))
+                    && let Some(&j) = to_index_by_key.get(&(schema, name))
                     && j != i
                 {
                     fk_targets[i].insert(j);
@@ -2087,6 +2115,35 @@ impl Comparer {
         // (not whitespace), `references_table` is followed by `_`
         // (still an identifier char), and `xxx_references` is
         // preceded by `_`.
+        // Track double-quoted regions across the whole scan so a
+        // column literally named `"my references col"` (the keyword
+        // appears mid-quote but is preceded and followed by spaces)
+        // doesn't pass the boundary check. PR #187 review.
+        let mut quote_open_at: Vec<usize> = Vec::new();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'"' {
+                if quote_open_at.last().copied() == Some(usize::MAX) {
+                    quote_open_at.pop();
+                } else {
+                    quote_open_at.push(usize::MAX);
+                }
+                quote_open_at.push(i);
+            }
+        }
+        // Reduce to a flat list of (open, close) byte ranges.
+        let mut quoted_ranges: Vec<(usize, usize)> = Vec::new();
+        let mut iter = quote_open_at.into_iter();
+        while let (Some(_), Some(open)) = (iter.next(), iter.next()) {
+            if let (Some(_), Some(close)) = (iter.next(), iter.next()) {
+                quoted_ranges.push((open, close));
+            }
+        }
+        let in_quoted_range = |idx: usize| -> bool {
+            quoted_ranges
+                .iter()
+                .any(|&(open, close)| idx > open && idx < close)
+        };
+
         let mut search_from = 0;
         let kw_pos = loop {
             if search_from + kw_len > bytes.len() {
@@ -2097,11 +2154,11 @@ impl Comparer {
             let left_ok = pos == 0
                 || !{
                     let b = bytes[pos - 1];
-                    b.is_ascii_alphanumeric() || b == b'_' || b == b'"'
+                    b.is_ascii_alphanumeric() || b == b'_' || b == b'"' || b == b'$'
                 };
             let after_kw = pos + kw_len;
             let right_ok = after_kw < bytes.len() && bytes[after_kw].is_ascii_whitespace();
-            if left_ok && right_ok {
+            if left_ok && right_ok && !in_quoted_range(pos) {
                 break pos;
             }
             // Advance one byte to keep ASCII-byte indices valid; the
@@ -2116,7 +2173,9 @@ impl Comparer {
 
         // Scan a single qualified identifier: identifier chars, dot,
         // or quoted segments. Stop at the first non-identifier byte
-        // outside quotes (typically `(` for the column list).
+        // outside quotes (typically `(` for the column list). PG
+        // identifiers may include `$`, so include it here — PR #187
+        // review.
         let mut end = 0;
         let mut in_quotes = false;
         for (i, ch) in after.char_indices() {
@@ -2129,7 +2188,7 @@ impl Comparer {
                 end = i + ch.len_utf8();
                 continue;
             }
-            if ch.is_alphanumeric() || ch == '_' || ch == '.' {
+            if ch.is_alphanumeric() || ch == '_' || ch == '.' || ch == '$' {
                 end = i + ch.len_utf8();
             } else {
                 break;
@@ -3609,12 +3668,17 @@ impl Comparer {
             let cascaded = match to_routines_by_full_id.get(&key) {
                 None => true,
                 Some(to_routine) => {
+                    // PR #187 review (C10/C11): defaults-only changes
+                    // are emitted via `CREATE OR REPLACE FUNCTION` —
+                    // they do NOT cause CASCADE drops, so Phase 7 must
+                    // also exclude them from `affected` or it would
+                    // emit pointless dependent recreates for routines
+                    // that PostgreSQL never dropped.
                     from_routine.hash.is_some()
                         && to_routine.hash.is_some()
                         && Self::hashes_differ(&from_routine.hash, &to_routine.hash)
                         && (from_routine.return_type != to_routine.return_type
-                            || from_routine.arguments != to_routine.arguments
-                            || from_routine.arguments_defaults != to_routine.arguments_defaults)
+                            || from_routine.arguments != to_routine.arguments)
                 }
             };
             if cascaded {
@@ -3633,6 +3697,30 @@ impl Comparer {
             }
         }
 
+        if affected.is_empty() {
+            return;
+        }
+
+        // PR #187 review (C16): only recreate dependents when at
+        // least one routine sharing the affected `(schema, name)`
+        // survives in TO. If the routine name is gone entirely from
+        // TO, dependents that text-match it would resolve to nothing
+        // — emitting a recreate would generate invalid SQL. The
+        // surviving routine may be a different overload (different
+        // argument types) but PostgreSQL's name-based binding will
+        // pick it up.
+        let surviving_routine_names: HashSet<(String, String)> = self
+            .to
+            .routines
+            .iter()
+            .map(|r| {
+                (
+                    r.schema.to_lowercase().replace('"', ""),
+                    r.name.to_lowercase().replace('"', ""),
+                )
+            })
+            .collect();
+        affected.retain(|key| surviving_routine_names.contains(key));
         if affected.is_empty() {
             return;
         }
@@ -3933,7 +4021,14 @@ impl Comparer {
     /// column references, type names, or string-literal contents do not
     /// trigger a false positive.
     fn definition_references_any(definition: &str, routines: &HashSet<(String, String)>) -> bool {
-        let (lower, unquoted) = Self::prelower_pair(definition);
+        // PR #187 review: blank out single-quoted string-literal
+        // contents before matching so a literal like
+        // `CHECK (msg <> 'compute(')` doesn't trip the matcher.
+        // `prelower_pair` only handles double quotes (identifier
+        // quoting); single quotes are SQL string literals and any
+        // routine-name lookalikes inside them must not count.
+        let scrubbed = Self::blank_single_quoted_literals(definition);
+        let (lower, unquoted) = Self::prelower_pair(&scrubbed);
         routines.iter().any(|(schema, name)| {
             // Both passes require a function-call context (`name(` after
             // optional whitespace). The qualified pass inherits this gate
@@ -3946,6 +4041,54 @@ impl Comparer {
             Self::text_references_qualified_call(&lower, &unquoted, schema, name)
                 || Self::text_references_unqualified_call(&unquoted, name)
         })
+    }
+
+    /// Replace every character inside single-quoted string literals
+    /// with a space (length-preserved so byte indices in callers stay
+    /// stable). Doubled-single-quote escapes (`''`) are treated as a
+    /// literal `'` inside the string and stay scrubbed. Used by the
+    /// Phase-7 dependency matcher (PR #187 review): a SQL string
+    /// literal like `'compute('` must not be mistaken for a function
+    /// call to `compute`.
+    fn blank_single_quoted_literals(text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut chars = text.chars();
+        while let Some(c) = chars.next() {
+            if c != '\'' {
+                out.push(c);
+                continue;
+            }
+            // Opening quote stays as-is so token boundaries are
+            // preserved; only the literal's body is scrubbed.
+            out.push('\'');
+            loop {
+                match chars.next() {
+                    Some('\'') => {
+                        if chars.as_str().starts_with('\'') {
+                            // doubled-quote escape — still inside the
+                            // literal, blank both single quotes' worth
+                            // of whitespace (one for the escape pair).
+                            out.push(' ');
+                            out.push(' ');
+                            chars.next();
+                        } else {
+                            out.push('\''); // closing quote
+                            break;
+                        }
+                    }
+                    Some(ch) => {
+                        // Replace each char with a space-equivalent
+                        // sequence of the same byte length so indices
+                        // in callers stay aligned with the original.
+                        for _ in 0..ch.len_utf8() {
+                            out.push(' ');
+                        }
+                    }
+                    None => break, // unterminated literal
+                }
+            }
+        }
+        out
     }
 
     /// Like [`Self::text_references_qualified_name_pre`] but additionally
@@ -4026,32 +4169,30 @@ impl Comparer {
         if name.is_empty() {
             return false;
         }
-        // Iterate via `match_indices`, which yields byte offsets that are
-        // guaranteed UTF-8 char boundaries. The previous loop used
-        // `text[start..]` with `start = i + 1`, which panics when `name`
-        // contains non-ASCII bytes (PostgreSQL allows Unicode
-        // identifiers like `"русское_имя"`): `i + 1` lands inside a
-        // multi-byte codepoint and the next slice fails. The boundary
-        // checks below are pure byte comparisons against ASCII, so a
-        // non-ASCII neighbour byte simply fails every `is_ascii_*` test
-        // — that's the desired behaviour, since the call gate further
-        // down requires `(` (after optional ASCII whitespace) and any
-        // non-paren byte exits without matching.
+        // `match_indices` yields byte offsets that are guaranteed UTF-8
+        // char boundaries — safe to slice around. PR #187 review: the
+        // boundary check now uses CHARACTER classification rather than
+        // raw byte tests so identifier-class Unicode neighbours
+        // (e.g. another Cyrillic letter next to a Cyrillic name) are
+        // correctly rejected. ASCII byte tests treated those bytes
+        // as non-identifier and would let `функция` match inside the
+        // longer identifier `мояфункция`.
         let bytes = text.as_bytes();
         let name_len = name.len();
+        let is_ident_continuation = |c: char| c.is_alphanumeric() || c == '_' || c == '$';
         for (i, _) in text.match_indices(name) {
-            if i > 0 {
-                let before = bytes[i - 1];
-                if before.is_ascii_alphanumeric() || before == b'_' || before == b'.' {
-                    continue;
-                }
+            if i > 0
+                && let Some(prev_ch) = text[..i].chars().next_back()
+                && (is_ident_continuation(prev_ch) || prev_ch == '.')
+            {
+                continue;
             }
             let end = i + name_len;
-            if end < bytes.len() {
-                let after = bytes[end];
-                if after.is_ascii_alphanumeric() || after == b'_' {
-                    continue;
-                }
+            if end < bytes.len()
+                && let Some(next_ch) = text[end..].chars().next()
+                && is_ident_continuation(next_ch)
+            {
+                continue;
             }
             let mut j = end;
             while j < bytes.len() && bytes[j].is_ascii_whitespace() {

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -1067,6 +1067,32 @@ impl Comparer {
             .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
             .collect();
 
+        // Tables whose persistence is flipping in this migration. The
+        // table-level `ALTER TABLE SET LOGGED|UNLOGGED` (emitted by the
+        // FK-ordered phase at the end of `compare_tables`) automatically
+        // propagates to every owned sequence, so re-emitting the same
+        // SET on the sequence — or, when persistence is the *only*
+        // diff, the entire ALTER SEQUENCE block — is redundant noise.
+        // See issue #180.
+        let tables_flipping_persistence: HashMap<(&str, &str), bool> = self
+            .to
+            .tables
+            .iter()
+            .filter_map(|to_table| {
+                let from_table = from_table_map
+                    .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                    .map(|&i| &self.from.tables[i])?;
+                from_table
+                    .persistence_change_for(to_table)
+                    .map(|new_unlogged| {
+                        (
+                            (to_table.schema.as_str(), to_table.name.as_str()),
+                            new_unlogged,
+                        )
+                    })
+            })
+            .collect();
+
         // We will find all new sequences from "to" dump that are not in "from" dump
         // and we will find all existing sequences in both dumps with different hashes
         // and add them to the script.
@@ -1096,11 +1122,31 @@ impl Comparer {
                     continue;
                 }
                 if Self::hashes_differ(&from_sequence.hash, &sequence.hash) {
+                    // Determine whether the owning table — if any — is
+                    // also flipping persistence in this migration.
+                    let owning_table_flipping = match (
+                        sequence.owned_by_schema.as_deref(),
+                        sequence.owned_by_table.as_deref(),
+                    ) {
+                        (Some(s), Some(t)) => tables_flipping_persistence.contains_key(&(s, t)),
+                        _ => false,
+                    };
+                    if owning_table_flipping && sequence.is_only_persistence_change(from_sequence) {
+                        // The whole ALTER SEQUENCE is redundant — the
+                        // owning table's `ALTER TABLE SET LOGGED|
+                        // UNLOGGED` propagates to this sequence on its
+                        // own. Suppress the entire emit (issue #180).
+                        continue;
+                    }
                     self.script.push_str(
                         format!("/* Sequence: {}.{}*/\n", sequence.schema, sequence.name).as_str(),
                     );
-                    self.script
-                        .push_str(sequence.get_alter_script(from_sequence).as_str());
+                    let alter = if owning_table_flipping {
+                        sequence.get_alter_script_excluding_persistence(from_sequence)
+                    } else {
+                        sequence.get_alter_script(from_sequence)
+                    };
+                    self.script.push_str(alter.as_str());
                 }
             } else {
                 // Check if the sequence is owned by a column that is an identity column or serial type.
@@ -1798,9 +1844,326 @@ impl Comparer {
                 .push_str(table.get_trigger_script().as_str());
         }
 
+        self.emit_persistence_changes();
+
         self.script
             .append_block("\n/* ---> Tables: End section --------------- */");
         Ok(())
+    }
+
+    /// Emit `ALTER TABLE ... SET LOGGED|UNLOGGED` statements in FK
+    /// topological order. PostgreSQL rejects the conversion when a
+    /// related table is in the wrong persistence state at the moment
+    /// the ALTER runs:
+    ///
+    ///   * `SET UNLOGGED` fails if any LOGGED table references the
+    ///     target via FK — every FK-referencing table must already be
+    ///     UNLOGGED.  Ordering: leaves before roots (reverse topo).
+    ///   * `SET LOGGED`   fails if the target references any UNLOGGED
+    ///     table via FK — every FK-referenced table must already be
+    ///     LOGGED.  Ordering: roots before leaves (forward topo).
+    ///
+    /// `Table::build_alter_script` deliberately omits the persistence
+    /// line so this single phase owns the order. See issue #180.
+    ///
+    /// **FK timing analysis** (issue #184 review thread): this phase
+    /// runs at the end of `compare_tables`, before `compare_foreign_
+    /// keys` has had a chance to add new FKs. The migration order is:
+    ///
+    ///   1. `compare_tables` per-table loop drops FKs whose
+    ///      definition changed (and FROM-only FKs alongside their
+    ///      table). Unchanged FKs are left in place.
+    ///   2. `emit_persistence_changes` (this method) runs the SETs.
+    ///   3. `compare_foreign_keys` re-adds modified FKs and creates
+    ///      new ones.
+    ///
+    /// So the live FK graph at the SET point is exactly the
+    /// **intersection** of FROM and TO by `(table, fk-name,
+    /// definition)` — neither the soon-to-be-added new FKs nor the
+    /// already-dropped modified FKs are active. The adjacency below
+    /// is built from that intersection (rather than the TO-side
+    /// constraints alone) so we don't impose ordering for FKs that
+    /// won't exist at the SET point and so we don't miss ordering
+    /// for FKs that DO exist but will later be dropped+re-added.
+    fn emit_persistence_changes(&mut self) {
+        let from_table_map: HashMap<(&str, &str), &Table> = self
+            .from
+            .tables
+            .iter()
+            .map(|t| ((t.schema.as_str(), t.name.as_str()), t))
+            .collect();
+
+        // Index every TO table once; the FK adjacency below and the
+        // subset orderings refer to tables by their position in
+        // `self.to.tables` to avoid borrow-tied pointer identity.
+        let to_index_by_key: HashMap<(&str, &str), usize> = self
+            .to
+            .tables
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ((t.schema.as_str(), t.name.as_str()), i))
+            .collect();
+
+        // Partition into the two flip directions; tables newly created
+        // (no FROM counterpart) do not need a SET — they're created
+        // with their TO-side persistence inline.
+        let mut to_unlogged: Vec<usize> = Vec::new();
+        let mut to_logged: Vec<usize> = Vec::new();
+        for (idx, to_table) in self.to.tables.iter().enumerate() {
+            let Some(from_table) = from_table_map
+                .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                .copied()
+            else {
+                continue;
+            };
+            match from_table.persistence_change_for(to_table) {
+                Some(true) => to_unlogged.push(idx),
+                Some(false) => to_logged.push(idx),
+                None => {}
+            }
+        }
+
+        if to_unlogged.is_empty() && to_logged.is_empty() {
+            return;
+        }
+
+        // FK adjacency restricted to the **live** FK set — FKs that
+        // exist in BOTH FROM and TO with the same definition. See the
+        // doc comment above this method for the timing rationale.
+        // `fk_targets[i]` holds the indices of tables that table `i`
+        // references via FK — i.e. `i` *depends on* those.
+        let mut fk_targets: Vec<HashSet<usize>> = vec![HashSet::new(); self.to.tables.len()];
+        for (i, to_table) in self.to.tables.iter().enumerate() {
+            // Lift the matching FROM table once so the FK lookup
+            // doesn't pay a per-constraint hashmap miss.
+            let from_table = from_table_map
+                .get(&(to_table.schema.as_str(), to_table.name.as_str()))
+                .copied();
+            for c in &to_table.constraints {
+                if !c.constraint_type.eq_ignore_ascii_case("foreign key") {
+                    continue;
+                }
+                let Some(def) = &c.definition else { continue };
+                // Live edge requires the same FK to exist in FROM with
+                // the same definition. A new FK (TO-only) won't be
+                // present at the SET point — `compare_foreign_keys`
+                // adds it later. A modified FK was dropped in the
+                // per-table ALTER loop and is also absent here. Both
+                // get filtered out.
+                let live = from_table
+                    .map(|ft| {
+                        ft.constraints.iter().any(|fc| {
+                            fc.name == c.name
+                                && fc.constraint_type.eq_ignore_ascii_case("foreign key")
+                                && fc.definition.as_deref() == c.definition.as_deref()
+                        })
+                    })
+                    .unwrap_or(false);
+                if !live {
+                    continue;
+                }
+                if let Some((schema, name)) = Self::parse_fk_referenced_table(def)
+                    && let Some(&j) = to_index_by_key.get(&(schema.as_str(), name.as_str()))
+                    && j != i
+                {
+                    fk_targets[i].insert(j);
+                }
+            }
+        }
+
+        // For SET UNLOGGED we want leaves (referencers) first. The
+        // generic toposort returns `dependencies before dependents`
+        // when fed `depends_on[i] = nodes i references`, so we reverse
+        // its output to get the dependent-first order this direction
+        // requires.
+        if !to_unlogged.is_empty() {
+            for table_idx in
+                Self::topo_order_within_subset(&to_unlogged, &fk_targets, &self.to.tables, true)
+            {
+                let table = &self.to.tables[table_idx];
+                self.script.append_block(&format!(
+                    "alter table {}.{} set unlogged;",
+                    table.schema, table.name
+                ));
+            }
+        }
+
+        // For SET LOGGED we want roots (referenced tables) first —
+        // forward topo order is exactly what we need.
+        if !to_logged.is_empty() {
+            for table_idx in
+                Self::topo_order_within_subset(&to_logged, &fk_targets, &self.to.tables, false)
+            {
+                let table = &self.to.tables[table_idx];
+                self.script.append_block(&format!(
+                    "alter table {}.{} set logged;",
+                    table.schema, table.name
+                ));
+            }
+        }
+    }
+
+    /// Order `subset` (absolute indices into `tables`) by FK
+    /// dependencies restricted to the subset itself. Edges to tables
+    /// outside the subset are ignored: a table the migration isn't
+    /// flipping doesn't constrain the SET ordering — only PostgreSQL's
+    /// runtime check against the live state does, and that's the
+    /// user's problem (they would have to add the missing flip to the
+    /// migration). With `dependents_first = true` returns reverse-topo
+    /// (leaves first — `SET UNLOGGED`); else forward-topo (roots
+    /// first — `SET LOGGED`). Result is a permutation of `subset`.
+    fn topo_order_within_subset(
+        subset: &[usize],
+        fk_targets: &[HashSet<usize>],
+        tables: &[Table],
+        dependents_first: bool,
+    ) -> Vec<usize> {
+        let n = subset.len();
+        let pos_in_subset: HashMap<usize, usize> = subset
+            .iter()
+            .enumerate()
+            .map(|(pos, &abs)| (abs, pos))
+            .collect();
+
+        let mut depends_on: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+        for (pos, &abs_idx) in subset.iter().enumerate() {
+            for &target_abs in &fk_targets[abs_idx] {
+                if let Some(&target_pos) = pos_in_subset.get(&target_abs)
+                    && target_pos != pos
+                {
+                    depends_on[pos].insert(target_pos);
+                }
+            }
+        }
+
+        let mut sorted = Self::kahn_toposort(n, &depends_on, |i| {
+            let t = &tables[subset[i]];
+            (t.schema.to_lowercase(), t.name.to_lowercase())
+        });
+        if dependents_first {
+            sorted.reverse();
+        }
+        sorted.into_iter().map(|pos| subset[pos]).collect()
+    }
+
+    /// Pull the `schema.name` of the table targeted by an FK constraint
+    /// definition (`pg_get_constraintdef` output, e.g.
+    /// `FOREIGN KEY (col) REFERENCES schema.table(col)`). Tolerates
+    /// quoted identifiers; returns `None` when the definition isn't
+    /// recognisably an FK or the referenced identifier is unqualified.
+    ///
+    /// The keyword scan is anchored to a whole-word match — a naive
+    /// `find("references ")` would false-match a column name like
+    /// `"references "` that happened to appear inside the FK column
+    /// list (or any earlier substring containing the literal text).
+    /// The schema/name split is quote-aware so a quoted identifier
+    /// that itself contains a literal `.`
+    /// (e.g. `REFERENCES "weird.schema"."t"(id)`) is split at the
+    /// dot OUTSIDE the quotes, not the first dot in byte order.
+    ///
+    /// The case-insensitive haystack is built with [`str::to_ascii_
+    /// lowercase`] rather than [`str::to_lowercase`]: the latter can
+    /// change byte length for some non-ASCII characters (e.g. capital
+    /// Turkish dotted I, which lowercases into a multi-character
+    /// sequence with a different UTF-8 length), and we slice back
+    /// into the original `def` using offsets that came from the
+    /// haystack — a length-changing lowercasing would leave those
+    /// offsets pointing inside a UTF-8 codepoint and panic.
+    /// `to_ascii_lowercase` is byte-length-preserving (only ASCII
+    /// letters change, every other byte is left intact) and the
+    /// keyword `references` is pure ASCII, so it's the right tool.
+    fn parse_fk_referenced_table(def: &str) -> Option<(String, String)> {
+        let lower = def.to_ascii_lowercase();
+        let bytes = lower.as_bytes();
+        let kw = b"references";
+        let kw_len = kw.len();
+
+        // Walk every occurrence of "references" until we find one that
+        // sits at an identifier word boundary AND is followed by
+        // whitespace — `pg_get_constraintdef` always renders the
+        // keyword that way. Substring matches inside quoted column
+        // names (the FK column list precedes the keyword) fail one of
+        // these checks: a quoted `"references"` is followed by `"`
+        // (not whitespace), `references_table` is followed by `_`
+        // (still an identifier char), and `xxx_references` is
+        // preceded by `_`.
+        let mut search_from = 0;
+        let kw_pos = loop {
+            if search_from + kw_len > bytes.len() {
+                return None;
+            }
+            let rel = lower[search_from..].find("references")?;
+            let pos = search_from + rel;
+            let left_ok = pos == 0
+                || !{
+                    let b = bytes[pos - 1];
+                    b.is_ascii_alphanumeric() || b == b'_' || b == b'"'
+                };
+            let after_kw = pos + kw_len;
+            let right_ok = after_kw < bytes.len() && bytes[after_kw].is_ascii_whitespace();
+            if left_ok && right_ok {
+                break pos;
+            }
+            // Advance one byte to keep ASCII-byte indices valid; the
+            // haystack is `lower` which is purely ASCII at byte 0 of
+            // each match candidate (because `find` lands on the
+            // ASCII keyword `references`).
+            search_from = pos + 1;
+        };
+
+        // Skip the keyword and the run of whitespace immediately after.
+        let after = (def[kw_pos + kw_len..]).trim_start();
+
+        // Scan a single qualified identifier: identifier chars, dot,
+        // or quoted segments. Stop at the first non-identifier byte
+        // outside quotes (typically `(` for the column list).
+        let mut end = 0;
+        let mut in_quotes = false;
+        for (i, ch) in after.char_indices() {
+            if ch == '"' {
+                in_quotes = !in_quotes;
+                end = i + ch.len_utf8();
+                continue;
+            }
+            if in_quotes {
+                end = i + ch.len_utf8();
+                continue;
+            }
+            if ch.is_alphanumeric() || ch == '_' || ch == '.' {
+                end = i + ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        let target = &after[..end];
+        Self::split_qualified_name_quote_aware(target)
+    }
+
+    /// Split a `schema.name` identifier at the first dot that lives
+    /// OUTSIDE any double-quoted segment. PostgreSQL allows quoted
+    /// identifiers to contain literal dots (`"weird.schema"`), so the
+    /// naive `target.find('.')` would split inside the quoted segment
+    /// and produce an invalid pair.
+    fn split_qualified_name_quote_aware(target: &str) -> Option<(String, String)> {
+        let bytes = target.as_bytes();
+        let mut in_quotes = false;
+        let mut split_at = None;
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'"' {
+                in_quotes = !in_quotes;
+            } else if b == b'.' && !in_quotes {
+                split_at = Some(i);
+                break;
+            }
+        }
+        let dot = split_at?;
+        let schema = target[..dot].trim_matches('"').to_string();
+        let name = target[dot + 1..].trim_matches('"').to_string();
+        if schema.is_empty() || name.is_empty() {
+            None
+        } else {
+            Some((schema, name))
+        }
     }
 
     // Comparing foreign keys

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -8239,6 +8239,480 @@ async fn issue179_full_drop_recreates_dependents_when_to_keeps_them() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Issue #180 — SET UNLOGGED / SET LOGGED statements must respect FK
+// dependencies (PostgreSQL rejects an out-of-order conversion), and
+// owned sequences should not redundantly re-emit the persistence flip
+// the table cascade already propagates.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Build a logged/unlogged-controlled table with a single FK to another
+/// table in the same schema, named with a numeric `id` PK column. Used
+/// by the issue-#180 ordering tests.
+fn issue180_logged_table(
+    schema: &str,
+    name: &str,
+    is_unlogged: bool,
+    fk_target: Option<(&str, &str, &str)>,
+) -> Table {
+    let mut id_col = int_column(schema, name, "id", 1);
+    id_col.is_nullable = false;
+
+    let mut constraints: Vec<TableConstraint> = vec![TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: schema.to_string(),
+        name: format!("{name}_pkey"),
+        table_name: name.to_string(),
+        constraint_type: "PRIMARY KEY".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("PRIMARY KEY (id)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    }];
+
+    let mut columns = vec![id_col];
+    if let Some((fk_col, fk_schema, fk_table)) = fk_target {
+        let mut ref_col = int_column(schema, name, fk_col, 2);
+        ref_col.is_nullable = true;
+        columns.push(ref_col);
+        constraints.push(TableConstraint {
+            catalog: "postgres".to_string(),
+            schema: schema.to_string(),
+            name: format!("{name}_{fk_col}_fkey"),
+            table_name: name.to_string(),
+            constraint_type: "FOREIGN KEY".to_string(),
+            is_deferrable: false,
+            initially_deferred: false,
+            definition: Some(format!(
+                "FOREIGN KEY ({fk_col}) REFERENCES {fk_schema}.{fk_table}(id)"
+            )),
+            coninhcount: 0,
+            is_enforced: true,
+            no_inherit: false,
+            nulls_not_distinct: false,
+            comment: None,
+        });
+    }
+
+    let mut table = Table::new(
+        schema.to_string(),
+        name.to_string(),
+        schema.to_string(),
+        name.to_string(),
+        "postgres".to_string(),
+        None,
+        columns,
+        constraints,
+        vec![],
+        vec![],
+        None,
+    );
+    table.is_unlogged = is_unlogged;
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue180_set_unlogged_orders_dependents_before_referenced() {
+    // FROM: three logged tables with FK chain
+    //   child -> parent -> grandparent.
+    // TO:   the same three tables, all UNLOGGED.
+    // PostgreSQL refuses `SET UNLOGGED` on a table while a LOGGED table
+    // still references it, so the conversion order must be leaves
+    // first: child, then parent, then grandparent.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        false,
+        None,
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        false,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        false,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        true,
+        None,
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        true,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_child = script
+        .find("alter table test_order.child set unlogged;")
+        .expect("child SET UNLOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set unlogged;")
+        .expect("parent SET UNLOGGED must be emitted");
+    let pos_grand = script
+        .find("alter table test_order.grandparent set unlogged;")
+        .expect("grandparent SET UNLOGGED must be emitted");
+
+    assert!(
+        pos_child < pos_parent && pos_parent < pos_grand,
+        "SET UNLOGGED must be ordered child -> parent -> grandparent (FK leaves first); got\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_set_logged_orders_referenced_before_dependents() {
+    // Reverse direction: all UNLOGGED -> all LOGGED.
+    // PostgreSQL refuses `SET LOGGED` while the table still references
+    // an UNLOGGED one, so order must be roots first: grandparent, then
+    // parent, then child.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        true,
+        None,
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        true,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "grandparent",
+        false,
+        None,
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "parent",
+        false,
+        Some(("grandparent_id", "test_order", "grandparent")),
+    ));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        false,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_grand = script
+        .find("alter table test_order.grandparent set logged;")
+        .expect("grandparent SET LOGGED must be emitted");
+    let pos_parent = script
+        .find("alter table test_order.parent set logged;")
+        .expect("parent SET LOGGED must be emitted");
+    let pos_child = script
+        .find("alter table test_order.child set logged;")
+        .expect("child SET LOGGED must be emitted");
+
+    assert!(
+        pos_grand < pos_parent && pos_parent < pos_child,
+        "SET LOGGED must be ordered grandparent -> parent -> child (FK roots first); got\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_persistence_change_does_not_emit_inline_inside_alter_table() {
+    // A table-level ALTER (e.g. add column) MUST NOT carry a SET
+    // UNLOGGED line — that would re-introduce the alphabetical ordering
+    // bug. The persistence flip is owned by the dedicated phase.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+
+    let mut to_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![
+            int_column("test_order", "items", "id", 1),
+            int_column("test_order", "items", "name", 2),
+        ],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    to_table.is_unlogged = true;
+    to_table.hash();
+
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    // SET UNLOGGED is still emitted, but only once and after the ADD
+    // COLUMN — not interleaved inside the per-table ALTER block.
+    let add_pos = script
+        .find("alter table test_order.items add column name")
+        .expect("add column must be emitted");
+    let set_pos = script
+        .find("alter table test_order.items set unlogged;")
+        .expect("set unlogged must be emitted by the dedicated phase");
+    assert!(
+        add_pos < set_pos,
+        "SET UNLOGGED must come from the dedicated phase, after the per-table ALTER: {}",
+        script
+    );
+    assert_eq!(
+        script.matches("set unlogged").count(),
+        1,
+        "SET UNLOGGED must be emitted exactly once (no inline + dedicated double-up): {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_owned_sequence_persistence_only_diff_is_skipped() {
+    // A sequence whose owning table flips persistence — and which has
+    // no other diff — produces a redundant `ALTER SEQUENCE ... SET
+    // UNLOGGED` followed by the full clause list. Both are noise: the
+    // table's `ALTER TABLE ... SET UNLOGGED` already cascades to all
+    // owned sequences. Suppress the entire ALTER SEQUENCE.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+
+    let mut to_table = from_table.clone();
+    to_table.is_unlogged = true;
+    to_table.hash();
+
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let make_seq = |is_unlogged: bool| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "items_id_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(1),
+            Some(1),
+            Some("test_order".to_string()),
+            Some("items".to_string()),
+            Some("id".to_string()),
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false));
+    to_dump.sequences.push(make_seq(true));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq"),
+        "owned-sequence persistence-only flip must be suppressed (table cascade handles it); got:\n{}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_owned_sequence_other_diff_skips_only_persistence_line() {
+    // When the sequence has a real change (e.g. cache_size) AND the
+    // owning table is also flipping persistence, we still need the
+    // ALTER SEQUENCE — but not the `SET UNLOGGED|LOGGED` line, because
+    // the table cascade handles that.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_table = Table::new(
+        "test_order".to_string(),
+        "items".to_string(),
+        "test_order".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![int_column("test_order", "items", "id", 1)],
+        vec![],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.is_unlogged = false;
+    from_table.hash();
+    let mut to_table = from_table.clone();
+    to_table.is_unlogged = true;
+    to_table.hash();
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let make_seq = |is_unlogged: bool, cache: i64| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "items_id_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(cache),
+            Some(1),
+            Some("test_order".to_string()),
+            Some("items".to_string()),
+            Some("id".to_string()),
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false, 1));
+    to_dump.sequences.push(make_seq(true, 5));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter sequence test_order.items_id_seq"),
+        "ALTER SEQUENCE must be emitted when non-persistence params changed: {}",
+        script
+    );
+    assert!(
+        script.contains("cache 5"),
+        "the changed cache value must be in the script: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter sequence test_order.items_id_seq set unlogged"),
+        "SET UNLOGGED on owned sequence is redundant when the owning table is flipping persistence: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue180_standalone_sequence_persistence_change_still_emits_set() {
+    // A sequence not owned by any table (or owned by a table whose
+    // persistence is unchanged) must still get its own SET because no
+    // table cascade applies.
+    use crate::dump::sequence::Sequence;
+
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let make_seq = |is_unlogged: bool| {
+        let mut s = Sequence::new(
+            "test_order".to_string(),
+            "global_seq".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    from_dump.sequences.push(make_seq(false));
+    to_dump.sequences.push(make_seq(true));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_sequences().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter sequence test_order.global_seq set unlogged"),
+        "standalone sequence must still emit SET UNLOGGED: {}",
+        script
+    );
+}
+
 #[tokio::test]
 async fn issue179_quoted_routine_names_match_unqualified_calls() {
     // PGC's dump query wraps `nspname` / `proname` with `quote_ident`,
@@ -8386,5 +8860,187 @@ async fn issue179_defaults_only_change_triggers_recreate() {
         script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
         "Phase 7 must recreate index on defaults-only change: {}",
         script
+    );
+}
+
+#[test]
+fn issue180_parse_fk_referenced_table_word_boundary() {
+    // PR #184 review: a naive `find("references ")` substring match
+    // can pick up the literal text inside a quoted column name in the
+    // FK column list. The matcher must be anchored to a word boundary
+    // and the keyword must be followed by whitespace.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col_a) REFERENCES public.target(id)"),
+        Some(("public".to_string(), "target".to_string())),
+        "happy-path FK definition must parse"
+    );
+    // Column literally named `"references "` (with trailing space) in
+    // the FK column list. Naive substring search would lock onto it
+    // before the real keyword and parse garbage.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"references \", col_b) REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // Column named `references_count` — substring match on
+    // "references" without the right-side word-boundary check would
+    // see this column first and try to parse what follows.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (references_count) REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+}
+
+#[test]
+fn issue180_parse_fk_referenced_table_quoted_identifier_with_dot() {
+    // PR #184 review: a quoted identifier may contain a literal `.`,
+    // and the schema/name split must respect quotes — otherwise the
+    // first dot inside the quoted segment is taken as the boundary
+    // and the parsed pair is nonsensical.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (col) REFERENCES \"weird.schema\".\"t\"(id)"
+        ),
+        Some(("weird.schema".to_string(), "t".to_string()))
+    );
+    // Both halves quoted with embedded dots — the split must still
+    // land on the dot OUTSIDE every quoted segment.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES \"a.b\".\"c.d\"(id)"),
+        Some(("a.b".to_string(), "c.d".to_string()))
+    );
+}
+
+#[test]
+fn issue180_parse_fk_referenced_table_handles_non_ascii_column_names() {
+    // PR #184 follow-up review: `parse_fk_referenced_table` previously
+    // built the case-insensitive haystack via `to_lowercase()`, which
+    // can change byte length for some non-ASCII characters
+    // (e.g. capital Turkish dotted I, `İ`, lowercases to a multi-char
+    // sequence with a different UTF-8 length). The keyword position
+    // came from the lowercased haystack but the slice that produces
+    // the parsed identifier reaches back into `def`, so a
+    // length-changing lowercasing would land mid-codepoint and panic.
+    // `to_ascii_lowercase()` is byte-length-preserving — pin that
+    // contract by parsing FK definitions whose column list contains
+    // identifiers that trip every byte-length-changing lowercase
+    // conversion in common locales.
+    //
+    // Quoted column with capital `İ` (U+0130). With `to_lowercase()`
+    // this produces `i\u{0307}` (3 bytes total); `to_ascii_lowercase`
+    // leaves the 2-byte `İ` alone, so byte offsets line up.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"\u{0130}d\") REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // German sharp S (`ß`, U+00DF). `to_lowercase()` keeps it as `ß`,
+    // but the inverse — uppercase `ẞ` (U+1E9E) lowercasing to `ß` —
+    // is length-preserving in UTF-8 too. Use a Cyrillic lowercase
+    // identifier here just to round out coverage of identifiers whose
+    // bytes lie outside the ASCII range.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"русское_имя\") REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string()))
+    );
+    // Same case in the qualified target identifier.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES \"тест\".\"target\"(id)"),
+        Some(("тест".to_string(), "target".to_string()))
+    );
+}
+
+#[tokio::test]
+async fn issue180_set_unlogged_skips_ordering_for_new_fks_added_later() {
+    // PR #184 review (FK-timing): when an FK is brand-new in TO it is
+    // not yet active at the moment `emit_persistence_changes` runs —
+    // `compare_foreign_keys` adds it strictly after. The adjacency
+    // must therefore filter to FKs that exist UNCHANGED in both
+    // FROM and TO. Without that filter, an alphabetical pair would
+    // be over-ordered as if the new FK were already live.
+    //
+    // Setup: child references parent in TO (new FK). FROM has no FK.
+    // Both flip from LOGGED to UNLOGGED.
+    //
+    // With the live-FK-set tightening, the adjacency is empty, so
+    // ordering falls back to alphabetical (deterministic via the
+    // sort_key in the topo sort). This is safe because PG won't see
+    // the FK link until after the SET phase.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump
+        .tables
+        .push(issue180_logged_table("test_order", "parent", false, None));
+    // FROM child has no FK to parent — the FK is new in TO.
+    from_dump
+        .tables
+        .push(issue180_logged_table("test_order", "child", false, None));
+    to_dump
+        .tables
+        .push(issue180_logged_table("test_order", "parent", true, None));
+    to_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    // Both SET UNLOGGED statements must be present; ordering between
+    // them is not constrained by the (not-yet-live) new FK.
+    assert!(script.contains("alter table test_order.child set unlogged;"));
+    assert!(script.contains("alter table test_order.parent set unlogged;"));
+}
+
+#[test]
+fn issue180_sequence_only_persistence_change_uses_hash_diff() {
+    // PR #184 review: `is_only_persistence_change` clones, equalises
+    // `is_unlogged` to FROM, recomputes the hash, and compares.
+    // That keeps the check honest if `Sequence::hash` later starts
+    // covering a new field. This test pins the contract by exercising
+    // both directions: identical-except-persistence returns true; a
+    // hashed field different (here `cache_size`) returns false.
+    use crate::dump::sequence::Sequence;
+
+    let make = |is_unlogged: bool, cache: i64| {
+        let mut s = Sequence::new(
+            "public".to_string(),
+            "s".to_string(),
+            "postgres".to_string(),
+            "integer".to_string(),
+            Some(1),
+            Some(1),
+            Some(2147483647),
+            Some(1),
+            false,
+            Some(cache),
+            Some(1),
+            None,
+            None,
+            None,
+        );
+        s.is_unlogged = is_unlogged;
+        s.hash();
+        s
+    };
+    let from = make(false, 1);
+    let to_only_persistence = make(true, 1);
+    let to_persistence_and_cache = make(true, 5);
+    assert!(
+        to_only_persistence.is_only_persistence_change(&from),
+        "identical except is_unlogged must be detected as persistence-only"
+    );
+    assert!(
+        !to_persistence_and_cache.is_only_persistence_change(&from),
+        "a hashed field difference must block the persistence-only suppression"
     );
 }

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -7952,14 +7952,16 @@ async fn issue179_quoted_routine_name_recreates_dependents() {
 }
 
 #[tokio::test]
-async fn issue179_defaults_only_change_recreates_dependents() {
-    // Defaults-only change: same return type, same arg list, but
-    // `arguments_defaults` differs. PostgreSQL has no `ALTER FUNCTION`
-    // for default values, so the comparer must DROP+CREATE the routine
-    // — and Phase 7 must in turn restore any CASCADE-dropped
-    // dependents. Exercises the `arguments_defaults`-in-hash fix
-    // end-to-end (without the hash inclusion, both `emit_routine_diff`
-    // and Phase 7 silently skip this case).
+async fn issue179_defaults_only_change_uses_create_or_replace_no_cascade() {
+    // PR #187 review (C10/C15): defaults-only changes must NOT
+    // trigger `DROP FUNCTION ... CASCADE`. PostgreSQL accepts
+    // default-argument changes via `CREATE OR REPLACE FUNCTION`
+    // when the identity argument types and return type are
+    // unchanged. The earlier version of this test pinned the
+    // destructive behaviour (DROP CASCADE + Phase 7 dependent
+    // recreates); the correct expectation is the non-destructive
+    // OR REPLACE form, with no CASCADE drop and no dependent
+    // recreates (since the function was never actually dropped).
     let mut from_dump = Dump::new(DumpConfig::default());
     let mut to_dump = Dump::new(DumpConfig::default());
 
@@ -8009,13 +8011,18 @@ async fn issue179_defaults_only_change_recreates_dependents() {
     let script = comparer.get_script();
 
     assert!(
-        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
-        "defaults-only change must trigger CASCADE drop: {}",
+        script.contains("create or replace function test_deps.compute(x integer DEFAULT 1)"),
+        "defaults-only change must be re-emitted via CREATE OR REPLACE: {}",
         script
     );
     assert!(
-        script.contains("alter table test_deps.items add constraint chk_compute"),
-        "dependent CHECK must be recreated after defaults-only DROP+CREATE: {}",
+        !script.contains("drop function if exists test_deps.compute"),
+        "defaults-only change must NOT emit DROP FUNCTION CASCADE: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter table test_deps.items add constraint chk_compute"),
+        "dependents must NOT be recreated when the function was not actually dropped: {}",
         script
     );
 }
@@ -8194,23 +8201,47 @@ async fn issue179_partition_child_skips_inherited_dependents() {
 }
 
 #[tokio::test]
-async fn issue179_full_drop_recreates_dependents_when_to_keeps_them() {
-    // Function is dropped from TO entirely, but the dependents remain
-    // in TO referencing some other expression (here we keep the same
-    // text reference simply to exercise the lookup — the test asserts
-    // the recreate path fires when TO still has the object).
+async fn issue179_full_drop_recreates_dependents_when_overload_survives() {
+    // PR #187 review (C16): the previous version of this test built
+    // an invalid PostgreSQL state — TO had dependents referencing
+    // `test_deps.compute` but no function with that name at all, so
+    // the recreate SQL would fail to apply. The valid scenario where
+    // "function fully dropped, dependents kept" is meaningful is when
+    // a *different overload* of the same name survives in TO and the
+    // dependents resolve to it via PostgreSQL's name-based function
+    // binding. Set that up explicitly here. FROM has both
+    // `compute(integer)` (which gets dropped) and `compute(text)`
+    // (the surviving overload). TO has only `compute(text)`.
+    // Dependents in both sides reference `test_deps.compute` and
+    // resolve via overload resolution.
     let mut from_dump = Dump::new(DumpConfig::default());
     let mut to_dump = Dump::new(DumpConfig::default());
 
     from_dump
         .routines
         .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    let mut compute_text_from = Routine::new(
+        "test_deps".to_string(),
+        Oid(961),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x text".to_string(),
+        None,
+        None,
+        "SELECT length(x);".to_string(),
+    );
+    compute_text_from.hash();
+    from_dump.routines.push(compute_text_from.clone());
+    // TO keeps only the text overload — `compute(integer)` is gone.
+    to_dump.routines.push(compute_text_from);
+
     from_dump.tables.push(issue179_items_table(
         "integer",
         "test_deps.compute(0)",
         "integer",
     ));
-    // TO has the table and dependents but no function.
     to_dump.tables.push(issue179_items_table(
         "integer",
         "test_deps.compute(0)",
@@ -8223,11 +8254,11 @@ async fn issue179_full_drop_recreates_dependents_when_to_keeps_them() {
 
     assert!(
         script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
-        "function must be dropped"
+        "the integer overload must be dropped"
     );
     assert!(
         script.contains("alter table test_deps.items add constraint chk_compute"),
-        "CHECK present in TO must be re-added after CASCADE"
+        "CHECK present in TO must be re-added after CASCADE (overload-resolves to surviving compute)"
     );
     assert!(
         script.contains("CREATE INDEX IF NOT EXISTS idx_compute"),
@@ -8809,12 +8840,14 @@ async fn issue179_quoted_routine_names_match_unqualified_calls() {
 }
 
 #[tokio::test]
-async fn issue179_defaults_only_change_triggers_recreate() {
-    // PostgreSQL has no `ALTER FUNCTION ... ARGUMENT ... DEFAULT`, so a
-    // defaults-only change requires DROP+CREATE. Routine::hash() now
-    // includes `arguments_defaults` so `emit_routine_diff` sees a hash
-    // diff and Phase 7 detects the CASCADE — the dependents must be
-    // recreated.
+async fn issue179_defaults_only_change_emits_create_or_replace_no_cascade() {
+    // PR #187 review (C10/C15): PostgreSQL accepts default-argument
+    // changes via `CREATE OR REPLACE FUNCTION` for the same identity
+    // signature/return type — there is no DROP+CREATE requirement.
+    // The `arguments_defaults` field is included in `Routine::hash()`
+    // so the diff is *detected*; the migration is then emitted as a
+    // plain `CREATE OR REPLACE` form (no CASCADE drop, no Phase 7
+    // dependent recreates).
     let mut from_dump = Dump::new(DumpConfig::default());
     let mut to_dump = Dump::new(DumpConfig::default());
 
@@ -8847,18 +8880,23 @@ async fn issue179_defaults_only_change_triggers_recreate() {
     let script = comparer.get_script();
 
     assert!(
-        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
-        "defaults-only change must still emit CASCADE drop: {}",
+        script.contains("create or replace function test_deps.compute(x integer DEFAULT 1)"),
+        "defaults-only change must use CREATE OR REPLACE FUNCTION: {}",
         script
     );
     assert!(
-        script.contains("alter table test_deps.items add constraint chk_compute"),
-        "Phase 7 must fire on defaults-only change: {}",
+        !script.contains("drop function if exists test_deps.compute"),
+        "defaults-only change must NOT emit DROP FUNCTION CASCADE: {}",
         script
     );
     assert!(
-        script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
-        "Phase 7 must recreate index on defaults-only change: {}",
+        !script.contains("alter table test_deps.items add constraint chk_compute"),
+        "Phase 7 must NOT fire on defaults-only change (no CASCADE happened): {}",
+        script
+    );
+    assert!(
+        !script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
+        "no index recreate on defaults-only change: {}",
         script
     );
 }
@@ -8911,6 +8949,202 @@ fn issue180_parse_fk_referenced_table_quoted_identifier_with_dot() {
     assert_eq!(
         Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES \"a.b\".\"c.d\"(id)"),
         Some(("a.b".to_string(), "c.d".to_string()))
+    );
+}
+
+#[test]
+fn pr187_parse_fk_skips_keyword_inside_quoted_column_name() {
+    // PR #187 review (C7): a column literally named
+    // `"my references col"` puts the bytes `references` between two
+    // spaces, passing the naive boundary check, then returns `None`
+    // from the false match without ever reaching the real keyword.
+    // The scanner must skip matches that fall inside a double-quoted
+    // identifier.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table(
+            "FOREIGN KEY (\"my references col\") REFERENCES public.target(id)"
+        ),
+        Some(("public".to_string(), "target".to_string())),
+        "FK keyword must still be located even with `references` inside a quoted column name"
+    );
+}
+
+#[test]
+fn pr187_parse_fk_handles_dollar_in_identifier() {
+    // PR #187 review (C8): PostgreSQL identifiers may contain `$`,
+    // so the unquoted-identifier scan must include it. Otherwise a
+    // target like `public.parent$table` is truncated to
+    // `public.parent`.
+    assert_eq!(
+        Comparer::parse_fk_referenced_table("FOREIGN KEY (col) REFERENCES public.parent$table(id)"),
+        Some(("public".to_string(), "parent$table".to_string()))
+    );
+}
+
+#[test]
+fn pr187_definition_references_any_skips_string_literals() {
+    // PR #187 review (C4): a SQL string literal containing routine
+    // text — `CHECK (msg <> 'compute(value)')` — must not trigger
+    // the unqualified-call matcher. The `definition_references_any`
+    // pre-pass must blank out single-quoted literals before scanning.
+    let mut affected: HashSet<(String, String)> = HashSet::new();
+    affected.insert(("public".to_string(), "compute".to_string()));
+    assert!(
+        !Comparer::definition_references_any("CHECK (msg <> 'compute(value)')", &affected),
+        "literal text must not be treated as a function call"
+    );
+    // Sanity check: a real call outside a literal still matches.
+    assert!(
+        Comparer::definition_references_any(
+            "CHECK (compute(value) > 0 AND msg <> 'compute(value)')",
+            &affected
+        ),
+        "real call outside the literal must still match"
+    );
+}
+
+#[tokio::test]
+async fn pr187_persistence_ordering_works_with_quoted_identifiers() {
+    // PR #187 review (C2): mixed-case table names round-trip into
+    // `Table.schema` / `Table.name` with surrounding quotes
+    // (`quote_ident` in the dump query). The FK parser strips quotes
+    // from its returned `(schema, name)`. Without normalising the
+    // lookup map to the same quote-stripped form, FK edges between
+    // quoted-identifier tables go missing and persistence flips fall
+    // back to alphabetical order, which PostgreSQL rejects for FK
+    // chains. Build a parent→child chain whose names are quoted and
+    // assert the SET UNLOGGED order is leaves-first.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    let mk = |name: &str, is_unlogged: bool, fk: Option<(&str, &str, &str)>| {
+        // Wrap the schema/name in quotes the way `quote_ident` would.
+        let mut t = issue180_logged_table("\"TestOrder\"", name, is_unlogged, fk);
+        t.schema = "\"TestOrder\"".to_string();
+        t.raw_schema = "\"TestOrder\"".to_string();
+        t
+    };
+    from_dump.tables.push(mk("\"Grand\"", false, None));
+    from_dump.tables.push(mk(
+        "\"Parent\"",
+        false,
+        Some(("grand_id", "\"TestOrder\"", "\"Grand\"")),
+    ));
+    from_dump.tables.push(mk(
+        "\"Child\"",
+        false,
+        Some(("parent_id", "\"TestOrder\"", "\"Parent\"")),
+    ));
+    to_dump.tables.push(mk("\"Grand\"", true, None));
+    to_dump.tables.push(mk(
+        "\"Parent\"",
+        true,
+        Some(("grand_id", "\"TestOrder\"", "\"Grand\"")),
+    ));
+    to_dump.tables.push(mk(
+        "\"Child\"",
+        true,
+        Some(("parent_id", "\"TestOrder\"", "\"Parent\"")),
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_child = script
+        .find("alter table \"TestOrder\".\"Child\" set unlogged;")
+        .expect("child SET UNLOGGED missing");
+    let pos_parent = script
+        .find("alter table \"TestOrder\".\"Parent\" set unlogged;")
+        .expect("parent SET UNLOGGED missing");
+    let pos_grand = script
+        .find("alter table \"TestOrder\".\"Grand\" set unlogged;")
+        .expect("grand SET UNLOGGED missing");
+    assert!(
+        pos_child < pos_parent && pos_parent < pos_grand,
+        "FK-leaf-first order must hold for quoted identifiers too: {script}"
+    );
+}
+
+#[tokio::test]
+async fn pr187_persistence_ordering_includes_in_place_alterable_fks() {
+    // PR #187 review (C13): an FK whose definition differs only in
+    // an in-place-alterable property (deferrability, enforced,
+    // no_inherit, comment) is NOT dropped by `compare_tables` — it
+    // stays live until `compare_foreign_keys` ALTERs it. The live
+    // FK adjacency for the SET phase must include it, otherwise
+    // chains where one FK is being toggled deferrable/enforced fall
+    // back to alphabetical SET order.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+    from_dump
+        .tables
+        .push(issue180_logged_table("test_order", "parent", false, None));
+    from_dump.tables.push(issue180_logged_table(
+        "test_order",
+        "child",
+        false,
+        Some(("parent_id", "test_order", "parent")),
+    ));
+    to_dump
+        .tables
+        .push(issue180_logged_table("test_order", "parent", true, None));
+    let mut to_child = issue180_logged_table(
+        "test_order",
+        "child",
+        true,
+        Some(("parent_id", "test_order", "parent")),
+    );
+    // Toggle the FK's deferrability — `can_be_altered_to` accepts
+    // this, so the FK survives `compare_tables` and is still live at
+    // the SET point.
+    if let Some(fk) = to_child
+        .constraints
+        .iter_mut()
+        .find(|c| c.constraint_type.eq_ignore_ascii_case("foreign key"))
+    {
+        fk.is_deferrable = true;
+        fk.initially_deferred = true;
+    }
+    to_child.hash();
+    to_dump.tables.push(to_child);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, false, false, true, GrantsMode::Ignore);
+    comparer.compare_tables().await.unwrap();
+    let script = comparer.get_script();
+
+    let pos_child = script
+        .find("alter table test_order.child set unlogged;")
+        .expect("child SET UNLOGGED missing");
+    let pos_parent = script
+        .find("alter table test_order.parent set unlogged;")
+        .expect("parent SET UNLOGGED missing");
+    assert!(
+        pos_child < pos_parent,
+        "child must come before parent even when the FK between them is being in-place ALTERed: {script}"
+    );
+}
+
+#[test]
+fn pr187_unqualified_matcher_unicode_boundary_rejects_longer_identifier() {
+    // PR #187 review (C17): the boundary check used raw ASCII byte
+    // tests, which treated Cyrillic neighbours as non-identifier and
+    // let `функция` match inside `мояфункция(`. The check now uses
+    // character-class identifier rules, so Cyrillic-letter neighbours
+    // correctly extend the identifier and reject the match.
+    let mut affected: HashSet<(String, String)> = HashSet::new();
+    affected.insert(("public".to_string(), "функция".to_string()));
+    assert!(
+        !Comparer::definition_references_any("CHECK (мояфункция(x) > 0)", &affected),
+        "unicode letter to the left must extend the identifier"
+    );
+    assert!(
+        !Comparer::definition_references_any("CHECK (функцияд(x) > 0)", &affected),
+        "unicode letter to the right must extend the identifier"
+    );
+    // Sanity: a clean Cyrillic call still matches.
+    assert!(
+        Comparer::definition_references_any("CHECK (функция(x) > 0)", &affected),
+        "standalone unicode call must still match"
     );
 }
 

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -6970,3 +6970,1421 @@ async fn mark_serial_columns_handles_dotted_identifier_names() {
         "dotted-name column must still be marked as serial"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Issue #179 — DROP FUNCTION ... CASCADE silently drops dependent
+// objects (functional indexes, CHECK constraints, generated columns,
+// column DEFAULT expressions, RLS policies). Phase 7 of
+// `compare_routines_and_views` re-emits them.
+// ─────────────────────────────────────────────────────────────────────
+
+use crate::dump::table_index::TableIndex;
+use crate::dump::table_policy::TablePolicy;
+
+/// Build a `Routine` mirroring `test_deps.compute(x integer)` from the
+/// issue report, parameterised by return type so a single helper covers
+/// both the FROM (integer) and TO (bigint) sides.
+fn issue179_compute_routine(return_type: &str, body: &str) -> Routine {
+    let mut routine = Routine::new(
+        "test_deps".to_string(),
+        Oid(900),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        return_type.to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        body.to_string(),
+    );
+    routine.hash();
+    routine
+}
+
+/// Construct an `items` table that mirrors the issue's example: each
+/// dependent (functional index, CHECK constraint, generated column,
+/// column DEFAULT, RLS policy) references `test_deps.compute`.
+fn issue179_items_table(value_type: &str, def_default: &str, gen_type: &str) -> Table {
+    let mut def_col = int_column("test_deps", "items", "def_col", 2);
+    def_col.data_type = value_type.to_string();
+    def_col.column_default = Some(def_default.to_string());
+
+    let mut gen_col = int_column("test_deps", "items", "gen_col", 3);
+    gen_col.data_type = gen_type.to_string();
+    gen_col.is_generated = "ALWAYS".to_string();
+    gen_col.generation_expression = Some("test_deps.compute(value)".to_string());
+    gen_col.generation_type = Some("s".to_string());
+
+    let mut value_col = int_column("test_deps", "items", "value", 1);
+    value_col.is_nullable = false;
+
+    let chk_constraint = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "test_deps".to_string(),
+        name: "chk_compute".to_string(),
+        table_name: "items".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("CHECK (test_deps.compute(value) > 0)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+
+    let idx = TableIndex {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "idx_compute".to_string(),
+        catalog: Some("postgres".to_string()),
+        indexdef:
+            "CREATE INDEX idx_compute ON test_deps.items USING btree (test_deps.compute(value))"
+                .to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+
+    let policy = TablePolicy {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "p_items".to_string(),
+        command: "all".to_string(),
+        permissive: true,
+        roles: vec![],
+        using_clause: Some("(test_deps.compute(value) > 0)".to_string()),
+        check_clause: None,
+    };
+
+    let mut table = Table::new(
+        "test_deps".to_string(),
+        "items".to_string(),
+        "test_deps".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col, def_col, gen_col],
+        vec![chk_constraint],
+        vec![idx],
+        vec![],
+        None,
+    );
+    table.policies = vec![policy];
+    table.has_rowsecurity = true;
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue179_signature_change_recreates_all_cascade_dependents() {
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)::integer",
+        "integer",
+    ));
+    to_dump.tables.push(issue179_items_table(
+        "bigint",
+        "test_deps.compute(0)",
+        "bigint",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    let drop_pos = script
+        .find("drop function if exists test_deps.compute (x integer) cascade;")
+        .expect("CASCADE drop must be emitted for the signature change");
+    let create_pos = script
+        .find("create or replace function test_deps.compute(x integer) returns bigint")
+        .expect("function recreate must be emitted");
+    assert!(drop_pos < create_pos);
+
+    // The recreate phase must run AFTER the function is recreated so the
+    // dependent objects can be created against the new function.
+    let chk_pos = script
+        .find("alter table test_deps.items add constraint chk_compute")
+        .expect("CHECK constraint must be re-added after CASCADE");
+    assert!(
+        create_pos < chk_pos,
+        "CHECK must be re-added after function recreate"
+    );
+    assert!(
+        script.contains("alter table test_deps.items drop constraint if exists chk_compute;"),
+        "drop-if-exists guard for CHECK constraint missing: {}",
+        script
+    );
+
+    let idx_pos = script
+        .find("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items")
+        .expect("functional index must be re-created (CREATE INDEX IF NOT EXISTS) after CASCADE");
+    assert!(create_pos < idx_pos);
+    // Index recreate is now non-destructive: no separate DROP INDEX is
+    // emitted (a false-positive match must not silently invalidate a
+    // surviving index — see Phase 7 / issue #179 review thread).
+    assert!(
+        !script.contains("drop index if exists test_deps.idx_compute;"),
+        "DROP INDEX must not be emitted; recreate uses CREATE INDEX IF NOT EXISTS"
+    );
+
+    // Generated column recreate is non-destructive: ADD COLUMN IF NOT
+    // EXISTS, no DROP COLUMN. A drop here would cascade to attached
+    // indexes / FKs / constraints that Phase 7 cannot restore.
+    assert!(
+        !script.contains("alter table test_deps.items drop column if exists gen_col"),
+        "DROP COLUMN must not be emitted for generated column recreate"
+    );
+    assert!(
+        script.contains("alter table test_deps.items add column if not exists gen_col bigint generated always as (test_deps.compute(value)) stored;"),
+        "generated column must be re-added (IF NOT EXISTS) with TO type/expression"
+    );
+
+    // Column DEFAULT: column survives, only the default is gone.
+    assert!(
+        script.contains(
+            "alter table test_deps.items alter column def_col set default test_deps.compute(0);"
+        ),
+        "column default must be restored from TO"
+    );
+    // We must NOT drop+re-add a non-generated column whose default was cascaded:
+    assert!(
+        !script.contains("drop column if exists def_col"),
+        "non-generated column must survive — only its DEFAULT clause was cascaded"
+    );
+
+    let policy_pos = script
+        .find("create policy p_items on test_deps.items")
+        .expect("policy must be re-created after CASCADE");
+    assert!(create_pos < policy_pos);
+    assert!(
+        script.contains("drop policy if exists p_items on test_deps.items;"),
+        "drop-if-exists guard for policy missing"
+    );
+}
+
+#[tokio::test]
+async fn issue179_recreate_skipped_when_routine_unchanged() {
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let routine = issue179_compute_routine("integer", "SELECT x * 2;");
+    from_dump.routines.push(routine.clone());
+    to_dump.routines.push(routine);
+
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+    to_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("Recreate dependents dropped by CASCADE"),
+        "no CASCADE drop happened — recreate phase must stay silent: {}",
+        script
+    );
+    assert!(!script.contains("alter table test_deps.items add constraint chk_compute"));
+    assert!(!script.contains("CREATE INDEX idx_compute"));
+    assert!(!script.contains("create policy p_items"));
+}
+
+#[tokio::test]
+async fn issue179_recreate_skipped_when_to_dependent_missing() {
+    // Function is dropped entirely. The dependent objects are also gone
+    // in TO (user removed both function and dependents). We must NOT
+    // resurrect the dependents — they're intentionally absent.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("alter table test_deps.items add constraint chk_compute"),
+        "CHECK must not be resurrected when neither it nor the function exist in TO"
+    );
+    assert!(
+        !script.contains("CREATE INDEX idx_compute"),
+        "index must not be resurrected when neither it nor the function exist in TO"
+    );
+    assert!(
+        !script.contains("create policy p_items"),
+        "policy must not be resurrected when neither it nor the function exist in TO"
+    );
+}
+
+/// Variant of [`issue179_items_table`] that mirrors PostgreSQL's
+/// deparser output when the function is reachable via `search_path`:
+/// the dependent texts use *unqualified* `compute(value)` instead of
+/// `test_deps.compute(value)`. The `pg_get_*` family routinely drops
+/// the schema qualifier in this case.
+fn issue179_items_table_unqualified(value_type: &str, def_default: &str, gen_type: &str) -> Table {
+    let mut def_col = int_column("test_deps", "items", "def_col", 2);
+    def_col.data_type = value_type.to_string();
+    def_col.column_default = Some(def_default.to_string());
+
+    let mut gen_col = int_column("test_deps", "items", "gen_col", 3);
+    gen_col.data_type = gen_type.to_string();
+    gen_col.is_generated = "ALWAYS".to_string();
+    // Unqualified function call.
+    gen_col.generation_expression = Some("compute(value)".to_string());
+    gen_col.generation_type = Some("s".to_string());
+
+    let mut value_col = int_column("test_deps", "items", "value", 1);
+    value_col.is_nullable = false;
+
+    let chk_constraint = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "test_deps".to_string(),
+        name: "chk_compute".to_string(),
+        table_name: "items".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        // Unqualified function call.
+        definition: Some("CHECK (compute(value) > 0)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+
+    let idx = TableIndex {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "idx_compute".to_string(),
+        catalog: Some("postgres".to_string()),
+        // Unqualified function call.
+        indexdef: "CREATE INDEX idx_compute ON test_deps.items USING btree (compute(value))"
+            .to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+
+    let policy = TablePolicy {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "p_items".to_string(),
+        command: "all".to_string(),
+        permissive: true,
+        roles: vec![],
+        // Unqualified function call.
+        using_clause: Some("(compute(value) > 0)".to_string()),
+        check_clause: None,
+    };
+
+    let mut table = Table::new(
+        "test_deps".to_string(),
+        "items".to_string(),
+        "test_deps".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col, def_col, gen_col],
+        vec![chk_constraint],
+        vec![idx],
+        vec![],
+        None,
+    );
+    table.policies = vec![policy];
+    table.has_rowsecurity = true;
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue179_unqualified_function_calls_are_detected() {
+    // PostgreSQL's pg_get_constraintdef / pg_get_indexdef / pg_get_expr
+    // drop the schema qualifier when the function is in search_path
+    // (the typical `public` case). Phase 7 must still recognise these
+    // dependents — otherwise the CASCADE-drop drift goes unfixed for
+    // anything the deparser deemed "in scope".
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.tables.push(issue179_items_table_unqualified(
+        "integer",
+        "compute(0)::integer",
+        "integer",
+    ));
+    to_dump.tables.push(issue179_items_table_unqualified(
+        "bigint",
+        "compute(0)",
+        "bigint",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "unqualified CHECK reference must trigger recreate: {}",
+        script
+    );
+    assert!(
+        script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
+        "unqualified index reference must trigger recreate: {}",
+        script
+    );
+    assert!(
+        script.contains(
+            "alter table test_deps.items add column if not exists gen_col bigint generated always as (compute(value)) stored;"
+        ),
+        "unqualified generated-column reference must trigger recreate: {}",
+        script
+    );
+    assert!(
+        script.contains("alter table test_deps.items alter column def_col set default compute(0);"),
+        "unqualified column DEFAULT reference must trigger recreate: {}",
+        script
+    );
+    assert!(
+        script.contains("create policy p_items on test_deps.items"),
+        "unqualified policy reference must trigger recreate: {}",
+        script
+    );
+}
+
+#[test]
+fn issue179_unqualified_match_rejects_substrings_and_non_calls() {
+    // Direct unit test for the boundary rules: the unqualified matcher
+    // must require `name(` at an identifier boundary, not match
+    // partial-name suffixes, qualified `schema.name`, or non-call uses.
+    let mut affected: HashSet<(String, String)> = HashSet::new();
+    affected.insert(("ignored_schema".to_string(), "compute".to_string()));
+
+    // Bare function call — should match.
+    assert!(Comparer::definition_references_any(
+        "check (compute(value) > 0)",
+        &affected
+    ));
+    // Whitespace between name and `(` — still a call.
+    assert!(Comparer::definition_references_any(
+        "check (compute  (value) > 0)",
+        &affected
+    ));
+    // Qualified — qualified matcher handles it via the schema, but we
+    // also exercise that the unqualified matcher's left-dot exclusion
+    // does not double-match `other_schema.compute(`.
+    assert!(!Comparer::definition_references_any(
+        "check (other_schema.compute(value) > 0)",
+        &affected
+    ));
+    // Substring — must NOT match.
+    assert!(!Comparer::definition_references_any(
+        "check (compute_v2(value) > 0)",
+        &affected
+    ));
+    assert!(!Comparer::definition_references_any(
+        "check (precompute(value) > 0)",
+        &affected
+    ));
+    // Identifier without trailing `(` — must NOT match.
+    assert!(!Comparer::definition_references_any(
+        "check (compute > 0)",
+        &affected
+    ));
+}
+
+#[test]
+fn issue179_unqualified_match_handles_non_ascii_identifiers() {
+    // PostgreSQL allows Unicode identifiers (quoted), and the dump's
+    // `quote_ident` machinery preserves them. After `prelower_pair`
+    // strips the surrounding quotes the haystack and needle both
+    // contain raw multi-byte UTF-8 — the previous implementation did
+    // `text[start..]` with `start = i + 1` and panicked on the next
+    // iteration because byte index `i + 1` lands inside a codepoint.
+    // Drive the matcher with a Cyrillic name and several haystacks to
+    // ensure: (a) it returns true for a real call, (b) it returns
+    // false for a non-call use without panicking, and (c) it returns
+    // false for a substring without panicking.
+    let mut affected: HashSet<(String, String)> = HashSet::new();
+    affected.insert(("test_schema".to_string(), "функция".to_string()));
+
+    assert!(Comparer::definition_references_any(
+        "check (функция(value) > 0)",
+        &affected
+    ));
+    assert!(!Comparer::definition_references_any(
+        "check (функция > 0)",
+        &affected
+    ));
+    // Repeated occurrences without a `(` — would have triggered the
+    // panic on the post-match `start = i + 1` advance.
+    assert!(!Comparer::definition_references_any(
+        "check (функция функция функция > 0)",
+        &affected
+    ));
+    // Substring (Cyrillic suffix) must not falsely match.
+    assert!(!Comparer::definition_references_any(
+        "check (функция_v2(value) > 0)",
+        &affected
+    ));
+}
+
+#[test]
+fn issue179_qualified_match_requires_call_context() {
+    // `pg_get_indexdef` emits `CREATE INDEX … ON schema.table …`,
+    // `pg_get_expr` emits `nextval('schema.seq'::regclass)`, etc.
+    // Without a call gate the qualified matcher would pick up those
+    // `schema.name` references whenever a routine happens to share its
+    // name with a table / view / sequence in the same schema, and
+    // Phase 7 would emit spurious recreates for unrelated objects.
+    let mut affected: HashSet<(String, String)> = HashSet::new();
+    affected.insert(("test_schema".to_string(), "users".to_string()));
+
+    // Match: real qualified function call.
+    assert!(Comparer::definition_references_any(
+        "check (test_schema.users(value) > 0)",
+        &affected,
+    ));
+    // Match with whitespace before `(`.
+    assert!(Comparer::definition_references_any(
+        "check (test_schema.users  (value) > 0)",
+        &affected,
+    ));
+
+    // No match: qualified reference is the table in a CREATE INDEX
+    // ON clause — not a function call.
+    assert!(!Comparer::definition_references_any(
+        "create index idx ON test_schema.users using btree (value)",
+        &affected,
+    ));
+    // No match: qualified reference inside a `nextval` regclass cast.
+    assert!(!Comparer::definition_references_any(
+        "nextval('test_schema.users'::regclass)",
+        &affected,
+    ));
+    // No match: identifier without a `(` after.
+    assert!(!Comparer::definition_references_any(
+        "check (test_schema.users > 0)",
+        &affected,
+    ));
+    // No match: qualified suffix of a longer name (boundary check).
+    assert!(!Comparer::definition_references_any(
+        "check (test_schema.users_v2(value) > 0)",
+        &affected,
+    ));
+}
+
+#[tokio::test]
+async fn issue179_to_side_gate_skips_dependents_no_longer_referencing_routine() {
+    // `compare_tables()` runs before `compare_routines_and_views()`, so
+    // dependents that have been rewritten to no longer reference the
+    // affected routine reach the CASCADE-drop step with the dependency
+    // already broken — PostgreSQL leaves them alone. Phase 7 must NOT
+    // re-emit recreates for those: doing so is at best wasteful and at
+    // worst destructive (a `DROP COLUMN IF EXISTS` for a generated
+    // column also drops every index / FK / constraint attached to the
+    // column, none of which Phase 7 restores).
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    // FROM table: every dependent references `test_deps.compute`.
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+
+    // TO table: dependents have been rewritten to NOT reference
+    // `test_deps.compute` anymore. After `compare_tables` runs they
+    // exist in this rewritten form, so the `DROP FUNCTION ... CASCADE`
+    // does not touch them.
+    let mut value_col = int_column("test_deps", "items", "value", 1);
+    value_col.is_nullable = false;
+
+    let mut def_col = int_column("test_deps", "items", "def_col", 2);
+    def_col.data_type = "integer".to_string();
+    def_col.column_default = Some("0".to_string()); // no longer references compute
+
+    let mut gen_col = int_column("test_deps", "items", "gen_col", 3);
+    gen_col.data_type = "integer".to_string();
+    gen_col.is_generated = "ALWAYS".to_string();
+    gen_col.generation_expression = Some("(value * 3)".to_string()); // no compute()
+    gen_col.generation_type = Some("s".to_string());
+
+    let chk = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "test_deps".to_string(),
+        name: "chk_compute".to_string(),
+        table_name: "items".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        // No compute() here either — TO swapped it out.
+        definition: Some("CHECK (value > 0)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+
+    let idx = TableIndex {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "idx_compute".to_string(),
+        catalog: Some("postgres".to_string()),
+        // No compute() in the index expression either.
+        indexdef: "CREATE INDEX idx_compute ON test_deps.items USING btree (value)".to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+
+    let policy = TablePolicy {
+        schema: "test_deps".to_string(),
+        table: "items".to_string(),
+        name: "p_items".to_string(),
+        command: "all".to_string(),
+        permissive: true,
+        roles: vec![],
+        // No compute() in the policy clause either.
+        using_clause: Some("(value > 0)".to_string()),
+        check_clause: None,
+    };
+
+    let mut to_table = Table::new(
+        "test_deps".to_string(),
+        "items".to_string(),
+        "test_deps".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col, def_col, gen_col],
+        vec![chk],
+        vec![idx],
+        vec![],
+        None,
+    );
+    to_table.policies = vec![policy];
+    to_table.has_rowsecurity = true;
+    to_table.hash();
+    to_dump.tables.push(to_table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    // Function still gets the CASCADE drop (signature change still
+    // requires DROP+CREATE).
+    assert!(
+        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
+        "function drop must still be emitted: {}",
+        script
+    );
+
+    // CRITICAL: the destructive generated-column path must stay silent.
+    assert!(
+        !script.contains("alter table test_deps.items drop column if exists gen_col"),
+        "generated column must NOT be dropped+re-added when TO no longer references the routine — that would cascade-destroy attached indexes/FKs without restoring them: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter table test_deps.items add column gen_col"),
+        "generated column add must not be emitted when TO does not reference the routine: {}",
+        script
+    );
+
+    // Constraint, index, and policy recreates must also be skipped to
+    // avoid redundant work that would conflict with `compare_tables`.
+    assert!(
+        !script.contains("alter table test_deps.items add constraint chk_compute"),
+        "CHECK recreate must not fire when TO definition no longer references the routine: {}",
+        script
+    );
+    assert!(
+        !script.contains("CREATE INDEX idx_compute ON test_deps.items"),
+        "index recreate must not fire when TO indexdef no longer references the routine: {}",
+        script
+    );
+    assert!(
+        !script.contains("create policy p_items"),
+        "policy recreate must not fire when TO clauses no longer reference the routine: {}",
+        script
+    );
+
+    // Column DEFAULT must also be skipped (TO default is `0`, no
+    // function reference).
+    assert!(
+        !script.contains("alter table test_deps.items alter column def_col set default 0;"),
+        "column DEFAULT recreate must not fire when TO default no longer references the routine: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue179_to_side_gate_still_recreates_when_to_keeps_reference() {
+    // Sanity check on the gate: when TO *does* still reference the
+    // affected routine (e.g. the dependent definition is unchanged),
+    // Phase 7 must continue to emit recreates exactly as before.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)::integer",
+        "integer",
+    ));
+    to_dump.tables.push(issue179_items_table(
+        "bigint",
+        "test_deps.compute(0)",
+        "bigint",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    // Each kind of dependent must be re-emitted because TO still
+    // references the routine.
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "CHECK constraint recreate expected when TO still references the routine: {}",
+        script
+    );
+    assert!(
+        script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
+        "index recreate expected when TO still references the routine: {}",
+        script
+    );
+    assert!(
+        script.contains("alter table test_deps.items add column if not exists gen_col"),
+        "generated column recreate expected when TO still references the routine: {}",
+        script
+    );
+    assert!(
+        script.contains(
+            "alter table test_deps.items alter column def_col set default test_deps.compute(0);"
+        ),
+        "column DEFAULT recreate expected when TO still references the routine: {}",
+        script
+    );
+    assert!(
+        script.contains("create policy p_items on test_deps.items"),
+        "policy recreate expected when TO still references the routine: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue179_overload_collision_does_not_destroy_unrelated_column() {
+    // Phase 7's `affected` set keys on `(schema, name)` and ignores the
+    // argument signature, because text-based reference matching cannot
+    // distinguish overloads (`compute(value)` in a CHECK or generation
+    // expression carries no type info). When `compute(integer)` is
+    // dropped+recreated and `compute(text)` is unchanged, a dependent
+    // referencing `compute(text_value)` will text-match the affected
+    // set even though CASCADE never touched it. The recreate paths
+    // must therefore be non-destructive — a `DROP COLUMN IF EXISTS`
+    // for a generated column would cascade through every index / FK /
+    // constraint attached to the column, none of which Phase 7 knows
+    // how to restore. This test pins the non-destructive contract.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    // FROM: two overloads. `compute(integer)` will change return type
+    // (forces DROP+CREATE); `compute(text)` is unchanged.
+    let mut from_int = Routine::new(
+        "test_deps".to_string(),
+        Oid(900),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    from_int.hash();
+    let mut from_text = Routine::new(
+        "test_deps".to_string(),
+        Oid(901),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x text".to_string(),
+        None,
+        None,
+        "SELECT length(x);".to_string(),
+    );
+    from_text.hash();
+    from_dump.routines.push(from_int);
+    from_dump.routines.push(from_text.clone());
+
+    // TO: same overloads, but `compute(integer)` now returns BIGINT.
+    let mut to_int = Routine::new(
+        "test_deps".to_string(),
+        Oid(900),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "bigint".to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        "SELECT (x * 2)::bigint;".to_string(),
+    );
+    to_int.hash();
+    to_dump.routines.push(to_int);
+    to_dump.routines.push(from_text); // text overload unchanged
+
+    // Build a table whose generated column references `compute(text_value)`
+    // — i.e. the unchanged `compute(text)` overload. CASCADE never
+    // drops this column (the dropped function is `compute(integer)`),
+    // so Phase 7 must NOT emit a destructive recreate.
+    let make_table = || {
+        let mut text_col = int_column("test_deps", "items", "text_value", 1);
+        text_col.data_type = "text".to_string();
+        text_col.is_nullable = false;
+        let mut gen_col = int_column("test_deps", "items", "gen_col", 2);
+        gen_col.is_generated = "ALWAYS".to_string();
+        gen_col.generation_expression = Some("test_deps.compute(text_value)".to_string());
+        gen_col.generation_type = Some("s".to_string());
+        let mut table = Table::new(
+            "test_deps".to_string(),
+            "items".to_string(),
+            "test_deps".to_string(),
+            "items".to_string(),
+            "postgres".to_string(),
+            None,
+            vec![text_col, gen_col],
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
+        table.hash();
+        table
+    };
+    from_dump.tables.push(make_table());
+    to_dump.tables.push(make_table());
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    // The integer overload is still cascaded.
+    assert!(
+        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
+        "integer overload must still be DROP+CREATEd: {}",
+        script
+    );
+
+    // CRITICAL: Phase 7 must NOT emit a DROP COLUMN. The text matcher
+    // false-positives on the affected set (which collapses overloads
+    // by name), so without IF NOT EXISTS the unconditional drop would
+    // destroy the unrelated column. Pinning this prevents regression.
+    assert!(
+        !script.contains("drop column if exists gen_col"),
+        "overload collision must not emit DROP COLUMN — would cascade-destroy attached indexes/FKs: {}",
+        script
+    );
+    // The recreate that *is* emitted must use IF NOT EXISTS so the
+    // surviving column is left intact when the script runs.
+    if let Some(add_idx) = script.find("alter table test_deps.items add column") {
+        let snippet = &script[add_idx..(add_idx + 80).min(script.len())];
+        assert!(
+            snippet.contains("if not exists"),
+            "ADD COLUMN must use IF NOT EXISTS to be non-destructive on overload false-positives: {}",
+            snippet
+        );
+    }
+}
+
+#[tokio::test]
+async fn issue179_quoted_routine_name_recreates_dependents() {
+    // The dump query wraps `proname` with `quote_ident`, so a
+    // mixed-case routine like `MyFunc` arrives as `"MyFunc"`. The
+    // unqualified-call matcher operates on the quote-stripped haystack,
+    // so the affected-routine name must also be quote-stripped or
+    // dependents like `CHECK ("MyFunc"(value) > 0)` are missed.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_routine = Routine::new(
+        "\"MySchema\"".to_string(),
+        Oid(950),
+        "\"MyFunc\"".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    from_routine.hash();
+    from_dump.routines.push(from_routine);
+
+    let mut to_routine = Routine::new(
+        "\"MySchema\"".to_string(),
+        Oid(950),
+        "\"MyFunc\"".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "bigint".to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        "SELECT (x * 2)::bigint;".to_string(),
+    );
+    to_routine.hash();
+    to_dump.routines.push(to_routine);
+
+    let mut value_col = int_column("public", "items", "value", 1);
+    value_col.is_nullable = false;
+
+    let chk = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "public".to_string(),
+        name: "chk_my".to_string(),
+        table_name: "items".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("CHECK (\"MyFunc\"(value) > 0)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+
+    let mut from_table = Table::new(
+        "public".to_string(),
+        "items".to_string(),
+        "public".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col.clone()],
+        vec![chk.clone()],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.hash();
+    let mut to_table = Table::new(
+        "public".to_string(),
+        "items".to_string(),
+        "public".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col],
+        vec![chk],
+        vec![],
+        vec![],
+        None,
+    );
+    to_table.hash();
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter table public.items add constraint chk_my"),
+        "quoted-name function reference must trigger CHECK recreate: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue179_defaults_only_change_recreates_dependents() {
+    // Defaults-only change: same return type, same arg list, but
+    // `arguments_defaults` differs. PostgreSQL has no `ALTER FUNCTION`
+    // for default values, so the comparer must DROP+CREATE the routine
+    // — and Phase 7 must in turn restore any CASCADE-dropped
+    // dependents. Exercises the `arguments_defaults`-in-hash fix
+    // end-to-end (without the hash inclusion, both `emit_routine_diff`
+    // and Phase 7 silently skip this case).
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_routine = Routine::new(
+        "test_deps".to_string(),
+        Oid(951),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        Some("DEFAULT 0".to_string()),
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    from_routine.hash();
+    from_dump.routines.push(from_routine);
+
+    let mut to_routine = Routine::new(
+        "test_deps".to_string(),
+        Oid(951),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        Some("DEFAULT 1".to_string()),
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    to_routine.hash();
+    to_dump.routines.push(to_routine);
+
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+    to_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
+        "defaults-only change must trigger CASCADE drop: {}",
+        script
+    );
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "dependent CHECK must be recreated after defaults-only DROP+CREATE: {}",
+        script
+    );
+}
+
+/// Build a partition child of `parent_table` whose dependents (CHECK
+/// constraint with `coninhcount=1`, `is_partition_index=true` index, a
+/// generated column, and a CHECK with `coninhcount=0` so we can prove
+/// the truly-local case is still emitted) all reference
+/// `test_deps.compute`. Used by the partition-child guard tests.
+fn issue179_items_partition_child(parent_qualified: &str) -> Table {
+    let mut value_col = int_column("test_deps", "items_2026", "value", 1);
+    value_col.is_nullable = false;
+
+    let mut gen_col = int_column("test_deps", "items_2026", "gen_col", 2);
+    gen_col.is_generated = "ALWAYS".to_string();
+    gen_col.generation_expression = Some("test_deps.compute(value)".to_string());
+    gen_col.generation_type = Some("s".to_string());
+
+    let inherited_check = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "test_deps".to_string(),
+        name: "chk_compute".to_string(),
+        table_name: "items_2026".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("CHECK (test_deps.compute(value) > 0)".to_string()),
+        coninhcount: 1,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+    let mut local_check = inherited_check.clone();
+    local_check.name = "chk_compute_local".to_string();
+    local_check.coninhcount = 0;
+
+    let inherited_idx = TableIndex {
+        schema: "test_deps".to_string(),
+        table: "items_2026".to_string(),
+        name: "idx_compute".to_string(),
+        catalog: Some("postgres".to_string()),
+        indexdef: "CREATE INDEX idx_compute ON test_deps.items_2026 USING btree (test_deps.compute(value))".to_string(),
+        is_partition_index: true,
+        comment: None,
+    };
+
+    let mut table = Table::new(
+        "test_deps".to_string(),
+        "items_2026".to_string(),
+        "test_deps".to_string(),
+        "items_2026".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col, gen_col],
+        vec![inherited_check, local_check],
+        vec![inherited_idx],
+        vec![],
+        None,
+    );
+    table.partition_of = Some(parent_qualified.to_string());
+    table.partition_bound = Some("FOR VALUES IN (1)".to_string());
+    table.hash();
+    table
+}
+
+#[tokio::test]
+async fn issue179_partition_child_skips_inherited_dependents() {
+    // FROM and TO each contain a partitioned parent + one partition
+    // child. The function signature changes, so CASCADE drops the
+    // parent-side dependents. Phase 7 must NOT emit recreates for the
+    // child's inherited objects (PostgreSQL forbids `ALTER TABLE child`
+    // on inherited columns/constraints/indexes), but it MUST still
+    // emit the truly-local CHECK constraint (`coninhcount = 0`).
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    // Parent (partitioned) carries the dependent definitions on its own
+    // row — its recreate handles the propagation to children.
+    let mut parent_from =
+        issue179_items_table("integer", "test_deps.compute(0)::integer", "integer");
+    parent_from.name = "items".to_string();
+    parent_from.raw_name = "items".to_string();
+    parent_from.partition_key = Some("LIST (value)".to_string());
+    parent_from.hash();
+
+    let mut parent_to = issue179_items_table("bigint", "test_deps.compute(0)", "bigint");
+    parent_to.name = "items".to_string();
+    parent_to.raw_name = "items".to_string();
+    parent_to.partition_key = Some("LIST (value)".to_string());
+    parent_to.hash();
+
+    from_dump.tables.push(parent_from);
+    to_dump.tables.push(parent_to);
+
+    from_dump
+        .tables
+        .push(issue179_items_partition_child("test_deps.items"));
+    to_dump
+        .tables
+        .push(issue179_items_partition_child("test_deps.items"));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    // Parent dependents (which Table::diff would diff normally) MUST
+    // be recreated against the parent.
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "parent CHECK must be re-added: {}",
+        script
+    );
+    assert!(
+        script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items "),
+        "parent index must be re-created: {}",
+        script
+    );
+
+    // Inherited child constraint (coninhcount > 0) must NOT be re-added
+    // on the child — PostgreSQL would reject `ALTER TABLE child ADD
+    // CONSTRAINT` for an inherited constraint, and the parent's recreate
+    // already propagates. (Use exact-suffix match so we don't accidentally
+    // match `chk_compute_local` below.)
+    assert!(
+        !script.contains("alter table test_deps.items_2026 drop constraint if exists chk_compute;"),
+        "inherited child CHECK must not be re-emitted: {}",
+        script
+    );
+    assert!(
+        !script.contains("alter table test_deps.items_2026 add constraint chk_compute check"),
+        "inherited child CHECK must not be re-added: {}",
+        script
+    );
+
+    // Truly-local child constraint (coninhcount == 0) IS re-emitted.
+    assert!(
+        script.contains(
+            "alter table test_deps.items_2026 drop constraint if exists chk_compute_local;"
+        ),
+        "local child CHECK must be re-emitted: {}",
+        script
+    );
+    assert!(
+        script.contains("alter table test_deps.items_2026 add constraint chk_compute_local"),
+        "local child CHECK must be re-added: {}",
+        script
+    );
+
+    // Partition-inherited index: must not be re-emitted on the child.
+    // Match by the load-bearing fragment so the assertion holds whether
+    // the recreate uses `CREATE INDEX` or `CREATE INDEX IF NOT EXISTS`.
+    assert!(
+        !script.contains("idx_compute ON test_deps.items_2026"),
+        "partition-inherited index must not be re-emitted on child: {}",
+        script
+    );
+
+    // Partition child's generated column must NOT be added — PostgreSQL
+    // forbids modifying inherited columns directly on a partition.
+    // (Recreate paths never emit DROP COLUMN now; the add assertion
+    // below is the load-bearing one for partition-child safety.)
+    assert!(
+        !script.contains("alter table test_deps.items_2026 add column if not exists gen_col"),
+        "partition child column must not be re-added: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue179_full_drop_recreates_dependents_when_to_keeps_them() {
+    // Function is dropped from TO entirely, but the dependents remain
+    // in TO referencing some other expression (here we keep the same
+    // text reference simply to exercise the lookup — the test asserts
+    // the recreate path fires when TO still has the object).
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    from_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+    // TO has the table and dependents but no function.
+    to_dump.tables.push(issue179_items_table(
+        "integer",
+        "test_deps.compute(0)",
+        "integer",
+    ));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
+        "function must be dropped"
+    );
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "CHECK present in TO must be re-added after CASCADE"
+    );
+    assert!(
+        script.contains("CREATE INDEX IF NOT EXISTS idx_compute"),
+        "functional index present in TO must be re-created (IF NOT EXISTS) after CASCADE"
+    );
+    assert!(
+        script.contains("create policy p_items on test_deps.items"),
+        "policy present in TO must be re-created after CASCADE"
+    );
+}
+
+#[tokio::test]
+async fn issue179_quoted_routine_names_match_unqualified_calls() {
+    // PGC's dump query wraps `nspname` / `proname` with `quote_ident`,
+    // so a function named `MyFunc` lands here as `Routine.name = "MyFunc"`.
+    // Phase 7 must strip those quotes when building its affected set —
+    // otherwise the unqualified matcher (which scans quote-stripped
+    // text) never lines up with the deparsed `myfunc(` in dependents.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_routine = Routine::new(
+        "\"TestDeps\"".to_string(),
+        Oid(900),
+        "\"MyFunc\"".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        None,
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    from_routine.hash();
+    let mut to_routine = from_routine.clone();
+    to_routine.return_type = "bigint".to_string();
+    to_routine.source_code = "SELECT (x * 2)::bigint;".to_string();
+    to_routine.hash();
+    from_dump.routines.push(from_routine);
+    to_dump.routines.push(to_routine);
+
+    // Dependent uses the deparsed unqualified form `"MyFunc"(value)`
+    // (PostgreSQL preserves the case-sensitive identifier with quotes
+    // but drops the schema qualifier when the function is in
+    // `search_path`).
+    let chk = TableConstraint {
+        catalog: "postgres".to_string(),
+        schema: "public".to_string(),
+        name: "chk_myfunc".to_string(),
+        table_name: "items".to_string(),
+        constraint_type: "CHECK".to_string(),
+        is_deferrable: false,
+        initially_deferred: false,
+        definition: Some("CHECK (\"MyFunc\"(value) > 0)".to_string()),
+        coninhcount: 0,
+        is_enforced: true,
+        no_inherit: false,
+        nulls_not_distinct: false,
+        comment: None,
+    };
+
+    let mut value_col = int_column("public", "items", "value", 1);
+    value_col.is_nullable = false;
+
+    let mut from_table = Table::new(
+        "public".to_string(),
+        "items".to_string(),
+        "public".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col.clone()],
+        vec![chk.clone()],
+        vec![],
+        vec![],
+        None,
+    );
+    from_table.hash();
+    let mut to_table = Table::new(
+        "public".to_string(),
+        "items".to_string(),
+        "public".to_string(),
+        "items".to_string(),
+        "postgres".to_string(),
+        None,
+        vec![value_col],
+        vec![chk],
+        vec![],
+        vec![],
+        None,
+    );
+    to_table.hash();
+    from_dump.tables.push(from_table);
+    to_dump.tables.push(to_table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("alter table public.items add constraint chk_myfunc"),
+        "quoted routine name must still match its unqualified deparsed dependent: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue179_defaults_only_change_triggers_recreate() {
+    // PostgreSQL has no `ALTER FUNCTION ... ARGUMENT ... DEFAULT`, so a
+    // defaults-only change requires DROP+CREATE. Routine::hash() now
+    // includes `arguments_defaults` so `emit_routine_diff` sees a hash
+    // diff and Phase 7 detects the CASCADE — the dependents must be
+    // recreated.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let mut from_routine = Routine::new(
+        "test_deps".to_string(),
+        Oid(900),
+        "compute".to_string(),
+        "sql".to_string(),
+        "FUNCTION".to_string(),
+        "integer".to_string(),
+        "x integer".to_string(),
+        Some("0".to_string()),
+        None,
+        "SELECT x * 2;".to_string(),
+    );
+    from_routine.hash();
+    let mut to_routine = from_routine.clone();
+    // ONLY the default value changes — every other field is identical.
+    to_routine.arguments_defaults = Some("1".to_string());
+    to_routine.hash();
+    from_dump.routines.push(from_routine);
+    to_dump.routines.push(to_routine);
+
+    let table = issue179_items_table("integer", "test_deps.compute(0)", "integer");
+    from_dump.tables.push(table.clone());
+    to_dump.tables.push(table);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("drop function if exists test_deps.compute (x integer) cascade;"),
+        "defaults-only change must still emit CASCADE drop: {}",
+        script
+    );
+    assert!(
+        script.contains("alter table test_deps.items add constraint chk_compute"),
+        "Phase 7 must fire on defaults-only change: {}",
+        script
+    );
+    assert!(
+        script.contains("CREATE INDEX IF NOT EXISTS idx_compute ON test_deps.items"),
+        "Phase 7 must recreate index on defaults-only change: {}",
+        script
+    );
+}

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -289,14 +289,23 @@ impl Routine {
         let rows_repr = self.rows.map_or(String::new(), |r| r.to_string());
         let support_repr = self.support_function.clone().unwrap_or_default();
         let transform_repr = self.transform_types.join(",");
+        // `arguments_defaults` participates in the hash because PostgreSQL
+        // has no `ALTER FUNCTION` for default values — a defaults-only
+        // change requires DROP+CREATE — and `Comparer::emit_routine_diff`
+        // (and Phase 7's CASCADE-recreate detection) gate that
+        // recreation on `hashes_differ`. Excluding defaults here would
+        // silently swallow defaults-only diffs and leave the database
+        // out of sync.
+        let defaults_repr = self.arguments_defaults.clone().unwrap_or_default();
         let src = format!(
-            "{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}",
+            "{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}",
             self.schema,
             self.name,
             self.lang,
             self.kind,
             self.return_type,
             self.arguments,
+            defaults_repr,
             self.owner,
             self.comment.clone().unwrap_or_default(),
             self.source_code,
@@ -851,13 +860,14 @@ mod tests {
         assert!(routine.aggregate_info.is_none());
 
         let expected_src = format!(
-            "{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}",
+            "{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}",
             schema,
             name,
             lang,
             kind,
             return_type,
             arguments,
+            defaults.as_deref().unwrap_or(""),
             "",
             "",
             source_code,
@@ -942,14 +952,18 @@ mod tests {
     }
 
     #[test]
-    fn hash_does_not_include_argument_defaults() {
+    fn hash_includes_argument_defaults() {
+        // PostgreSQL has no `ALTER FUNCTION` for default values — a
+        // defaults-only change requires DROP+CREATE — so the hash must
+        // reflect `arguments_defaults` or the comparer's `hashes_differ`
+        // gate would silently swallow the diff.
         let mut routine = build_function_routine();
         let original_hash = routine.hash.clone();
 
         routine.arguments_defaults = Some("DEFAULT 99".to_string());
         routine.hash();
 
-        assert_eq!(routine.hash, original_hash);
+        assert_ne!(routine.hash, original_hash);
     }
 
     #[test]

--- a/app/src/dump/routine.rs
+++ b/app/src/dump/routine.rs
@@ -289,13 +289,16 @@ impl Routine {
         let rows_repr = self.rows.map_or(String::new(), |r| r.to_string());
         let support_repr = self.support_function.clone().unwrap_or_default();
         let transform_repr = self.transform_types.join(",");
-        // `arguments_defaults` participates in the hash because PostgreSQL
-        // has no `ALTER FUNCTION` for default values — a defaults-only
-        // change requires DROP+CREATE — and `Comparer::emit_routine_diff`
-        // (and Phase 7's CASCADE-recreate detection) gate that
-        // recreation on `hashes_differ`. Excluding defaults here would
-        // silently swallow defaults-only diffs and leave the database
-        // out of sync.
+        // `arguments_defaults` participates in the hash so a
+        // defaults-only diff is *detected* — `Comparer::emit_routine_
+        // diff` keys off `hashes_differ` to decide whether to emit
+        // anything at all. The actual migration uses `CREATE OR
+        // REPLACE FUNCTION`, NOT `DROP FUNCTION ... CASCADE`:
+        // PostgreSQL accepts default-argument changes via the
+        // OR REPLACE form when the identity argument types and return
+        // type are unchanged. PR #187 review (C11) corrected the
+        // earlier wording here that misleadingly framed defaults as
+        // a DROP+CREATE requirement.
         let defaults_repr = self.arguments_defaults.clone().unwrap_or_default();
         let src = format!(
             "{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}.{}",

--- a/app/src/dump/sequence.rs
+++ b/app/src/dump/sequence.rs
@@ -224,11 +224,62 @@ impl Sequence {
     /// would rewind a live sequence whose current position is already above the new
     /// `start_value`, risking duplicate-key violations.
     pub fn get_alter_script(&self, from: &Sequence) -> String {
+        self.build_alter_script(from, true)
+    }
+
+    /// Same as [`Self::get_alter_script`] but never emits the
+    /// `ALTER SEQUENCE ... SET LOGGED|UNLOGGED` line. The comparer
+    /// uses this when the owning table is itself flipping persistence
+    /// in the same migration: PostgreSQL automatically propagates the
+    /// table's `ALTER TABLE SET LOGGED|UNLOGGED` to every owned
+    /// sequence, so re-emitting the SET on the sequence is redundant
+    /// (issue #180).
+    pub fn get_alter_script_excluding_persistence(&self, from: &Sequence) -> String {
+        self.build_alter_script(from, false)
+    }
+
+    /// True when the only field that differs between `self` (TO) and
+    /// `from` is `is_unlogged`. Used by the comparer to suppress an
+    /// otherwise no-op `ALTER SEQUENCE …` for owned sequences whose
+    /// owning table is flipping persistence (the table's `ALTER TABLE
+    /// SET LOGGED|UNLOGGED` propagates to the sequence on its own —
+    /// re-emitting the full clause list would be cosmetic noise).
+    ///
+    /// Implementation strategy: clone `self`, force its `is_unlogged`
+    /// back to `from`'s value, recompute the hash, and compare. This
+    /// piggy-backs on [`Self::hash`] so any new field added to the
+    /// hash is automatically considered here — there's no field list
+    /// to forget to update. We also explicitly compare the few fields
+    /// that `hash()` deliberately leaves out but `get_alter_script`
+    /// renders (`owned_by_*`); a change there must still block the
+    /// suppression because the table-cascade does NOT propagate
+    /// ownership changes.
+    pub fn is_only_persistence_change(&self, from: &Sequence) -> bool {
+        if self.is_unlogged == from.is_unlogged {
+            return false;
+        }
+        // Hash mismatch on the persistence-equalised clone means SOME
+        // hashed field other than `is_unlogged` differs.
+        let mut probe = self.clone();
+        probe.is_unlogged = from.is_unlogged;
+        probe.hash();
+        if probe.hash != from.hash {
+            return false;
+        }
+        // Ownership info is rendered in `get_alter_script` but not
+        // hashed — keep the explicit checks as a belt-and-braces guard
+        // against a behaviour-affecting change being silently dropped.
+        self.owned_by_schema == from.owned_by_schema
+            && self.owned_by_table == from.owned_by_table
+            && self.owned_by_column == from.owned_by_column
+    }
+
+    fn build_alter_script(&self, from: &Sequence, include_persistence: bool) -> String {
         let mut clauses = Vec::new();
 
         // Handle logged/unlogged change
         let mut logging_script = String::new();
-        if self.is_unlogged != from.is_unlogged {
+        if include_persistence && self.is_unlogged != from.is_unlogged {
             if self.is_unlogged {
                 logging_script =
                     format!("alter sequence {}.{} set unlogged;", self.schema, self.name)

--- a/app/src/dump/table.rs
+++ b/app/src/dump/table.rs
@@ -1811,21 +1811,18 @@ impl Table {
             ));
         }
 
-        // UNLOGGED / LOGGED change
-        if self.is_unlogged != to_table.is_unlogged {
-            let stmt = if to_table.is_unlogged {
-                format!(
-                    "alter table {}.{} set unlogged;",
-                    to_table.schema, to_table.name
-                )
-            } else {
-                format!(
-                    "alter table {}.{} set logged;",
-                    to_table.schema, to_table.name
-                )
-            };
-            script.append_block(&stmt);
-        }
+        // UNLOGGED / LOGGED change is emitted by the comparer in a
+        // separate FK-ordered phase (see issue #180). Doing it inline
+        // here would interleave SET UNLOGGED/LOGGED statements with the
+        // alphabetical table order PostgreSQL rejects:
+        //   * SET UNLOGGED fails if any LOGGED table references this
+        //     one — referencers (leaves) must be converted first.
+        //   * SET LOGGED   fails if this table references any UNLOGGED
+        //     one — referenced tables (roots) must be converted first.
+        // Both directions therefore need a topological pass that this
+        // per-table function can't perform. The comparer collects
+        // `Self::persistence_change_for(&to_table)` results from every
+        // pair and emits them in the right order at end of compare.
 
         // Storage parameters change
         if self.storage_parameters != to_table.storage_parameters {
@@ -1905,6 +1902,22 @@ impl Table {
     /// Get script for altering the table without triggers (for deferred trigger creation)
     pub fn get_alter_script_without_triggers(&self, to_table: &Table, use_drop: bool) -> String {
         self.build_alter_script(to_table, use_drop, false)
+    }
+
+    /// Returns `Some(target_is_unlogged)` when this table's logging
+    /// status differs from `to_table`. The comparer collects these per
+    /// (FROM, TO) pair and emits the resulting `ALTER TABLE ... SET
+    /// LOGGED|UNLOGGED` statements in FK-topological order (see issue
+    /// #180): inline emission in `build_alter_script` would honour the
+    /// alphabetical table iteration order, which PostgreSQL rejects
+    /// whenever a referencing-table / referenced-table pair flip
+    /// persistence in the same migration.
+    pub fn persistence_change_for(&self, to_table: &Table) -> Option<bool> {
+        if self.is_unlogged != to_table.is_unlogged {
+            Some(to_table.is_unlogged)
+        } else {
+            None
+        }
     }
 
     fn get_trigger_alter_parts(&self, to_table: &Table, use_drop: bool) -> (String, String) {

--- a/app/src/dump/table_column.rs
+++ b/app/src/dump/table_column.rs
@@ -545,31 +545,59 @@ impl TableColumn {
             self.build_identity_update_statements(existing, &mut statements);
         }
 
+        // Issue #181: `generation_type` (`s`/`v`) flips must also count
+        // as a change. PG18 introduced VIRTUAL generated columns and
+        // they CANNOT be ALTERed in place — neither
+        // `ALTER COLUMN DROP EXPRESSION` (which only works for
+        // STORED) nor `ALTER COLUMN ADD GENERATED ALWAYS AS (...)
+        // VIRTUAL` (invalid syntax) is valid. Without this check a
+        // STORED ↔ VIRTUAL flip with the same expression would be
+        // silently skipped.
+        let generation_type_changed = new_generated == "ALWAYS"
+            && old_generated == "ALWAYS"
+            && self.effective_generation_type() != existing.effective_generation_type();
         let generated_changed = new_generated != old_generated
             || (new_generated == "ALWAYS"
-                && self.generation_expression != existing.generation_expression);
+                && self.generation_expression != existing.generation_expression)
+            || generation_type_changed;
 
         if generated_changed {
             let new_is_generated = new_generated == "ALWAYS";
             let old_is_generated = old_generated != "NEVER";
 
-            if !old_is_generated && new_is_generated {
-                // Converting an existing column (especially with data) to GENERATED is not safely handled by a simple ALTER; drop and re-add instead.
+            // Whether either side is VIRTUAL — the in-place
+            // `DROP EXPRESSION` + `ADD GENERATED ... VIRTUAL` path
+            // PostgreSQL would otherwise be sent doesn't exist for
+            // VIRTUAL columns: DROP EXPRESSION rejects with
+            // `ALTER TABLE / DROP EXPRESSION is not supported for
+            // virtual generated columns`, and the ADD form never
+            // accepts VIRTUAL. The full DROP COLUMN + ADD COLUMN
+            // round-trip is the only correct migration. Flips of
+            // generation_type fall here for the same reason — even
+            // STORED → VIRTUAL with identical expression has no
+            // in-place ALTER. (Issue #181)
+            let needs_full_recreate = !old_is_generated && new_is_generated
+                || (old_is_generated
+                    && (existing.effective_generation_type() == "v"
+                        || self.effective_generation_type() == "v"));
+
+            if needs_full_recreate {
                 if use_drop {
                     statements.push(self.get_drop_script());
                     statements.push(self.get_add_script());
                 } else {
-                    let mut commented = String::from(
-                        "-- use_drop=false: converting column to generated requires drop/add; statements commented out\n",
-                    );
-
+                    let header = if !old_is_generated && new_is_generated {
+                        "-- use_drop=false: converting column to generated requires drop/add; statements commented out\n"
+                    } else {
+                        "-- use_drop=false: virtual generated column cannot be ALTERed in place (PG18+); drop/add required and statements commented out\n"
+                    };
+                    let mut commented = String::from(header);
                     for line in self.get_drop_script().lines() {
                         commented.push_str(&format!("-- {line}\n"));
                     }
                     for line in self.get_add_script().lines() {
                         commented.push_str(&format!("-- {line}\n"));
                     }
-
                     statements.push(commented);
                 }
             } else {
@@ -594,12 +622,12 @@ impl TableColumn {
                 if new_is_generated && let Some(expr) = &self.generation_expression {
                     let norm_expr = Self::normalized_generation_expression(expr);
                     let wrapped = format!("({norm_expr})");
-                    let gen_kind = match self.generation_type.as_deref() {
-                        Some("v") => "virtual",
-                        _ => "stored",
-                    };
+                    // We only reach this branch for STORED-side
+                    // additions — `needs_full_recreate` already
+                    // routed any VIRTUAL participant through the
+                    // drop+add path above.
                     let add_cmd = format!(
-                        "alter table {}.{} alter column {} add generated always as {wrapped} {gen_kind};",
+                        "alter table {}.{} alter column {} add generated always as {wrapped} stored;",
                         self.schema, self.table, self.name
                     ).with_empty_lines();
                     if use_drop || !old_is_generated {
@@ -1845,6 +1873,13 @@ mod tests {
 
     #[test]
     fn test_get_alter_script_update_virtual_generated_expression() {
+        // Issue #181: PG18 rejects `ALTER COLUMN DROP EXPRESSION` for
+        // VIRTUAL generated columns and has no `ALTER COLUMN ADD
+        // GENERATED ALWAYS AS (...) VIRTUAL` syntax. The only valid
+        // migration is a full `DROP COLUMN` + `ADD COLUMN ...
+        // GENERATED ALWAYS AS (...) VIRTUAL`. Pin that here — the
+        // previous test asserted the broken in-place ALTER form,
+        // which produced runtime errors against PG18.
         let mut existing = create_test_column();
         existing.is_generated = "ALWAYS".to_string();
         existing.generation_expression = Some("(id * 2)".to_string());
@@ -1858,12 +1893,123 @@ mod tests {
             .expect("expected alter statement for virtual expression change");
 
         assert!(
-            script.contains("drop expression"),
-            "expected drop expression: {script}"
+            script.contains("drop column test_column"),
+            "expected DROP COLUMN (virtual columns can't be ALTERed in place): {script}"
+        );
+        assert!(
+            !script.contains("drop expression"),
+            "must NOT emit `drop expression` for virtual columns (PG18 rejects it): {script}"
+        );
+        assert!(
+            script.contains("add column test_column"),
+            "expected ADD COLUMN to re-create the column: {script}"
         );
         assert!(
             script.contains("generated always as (id * 3) virtual"),
-            "expected virtual in re-add: {script}"
+            "expected new virtual generation expression in the re-add: {script}"
+        );
+    }
+
+    #[test]
+    fn issue181_stored_to_virtual_flip_emits_drop_and_add_column() {
+        // Issue #181 Bug 1: a STORED → VIRTUAL flip with the same
+        // generation expression must produce a migration. Before the
+        // fix the change-detection condition only inspected
+        // `is_generated` and `generation_expression`, so the flip was
+        // silently ignored. PG18 has no in-place ALTER for the
+        // storage kind so the only valid migration is DROP COLUMN +
+        // ADD COLUMN.
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+        existing.generation_type = Some("s".to_string());
+
+        let mut updated = existing.clone();
+        updated.generation_type = Some("v".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("STORED → VIRTUAL flip must emit a migration script");
+
+        assert!(
+            script.contains("drop column test_column"),
+            "expected DROP COLUMN: {script}"
+        );
+        assert!(
+            script.contains("add column test_column"),
+            "expected ADD COLUMN: {script}"
+        );
+        assert!(
+            script.contains("generated always as (id * 2) virtual"),
+            "expected the new VIRTUAL kind in the re-add: {script}"
+        );
+    }
+
+    #[test]
+    fn issue181_virtual_to_stored_flip_emits_drop_and_add_column() {
+        // Mirror of the case above, the other direction. Same
+        // requirement: PG18 has no in-place ALTER between VIRTUAL and
+        // STORED, so a full DROP+ADD is the only valid migration.
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+        existing.generation_type = Some("v".to_string());
+
+        let mut updated = existing.clone();
+        updated.generation_type = Some("s".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("VIRTUAL → STORED flip must emit a migration script");
+
+        assert!(
+            script.contains("drop column test_column"),
+            "expected DROP COLUMN: {script}"
+        );
+        assert!(
+            script.contains("add column test_column"),
+            "expected ADD COLUMN: {script}"
+        );
+        assert!(
+            script.contains("generated always as (id * 2) stored"),
+            "expected the new STORED kind in the re-add: {script}"
+        );
+        assert!(
+            !script.contains("drop expression"),
+            "must NOT emit `drop expression` (the VIRTUAL side rejects it): {script}"
+        );
+    }
+
+    #[test]
+    fn issue181_stored_expression_change_keeps_in_place_alter() {
+        // Sanity check: the in-place `DROP EXPRESSION` + `ADD
+        // GENERATED ... STORED` path is still used for the case that
+        // PG18 accepts — STORED → STORED with a new expression. Only
+        // VIRTUAL participants get routed to the heavier DROP COLUMN
+        // path.
+        let mut existing = create_test_column();
+        existing.is_generated = "ALWAYS".to_string();
+        existing.generation_expression = Some("(id * 2)".to_string());
+        existing.generation_type = Some("s".to_string());
+
+        let mut updated = existing.clone();
+        updated.generation_expression = Some("(id * 3)".to_string());
+
+        let script = updated
+            .get_alter_script(&existing, true)
+            .expect("STORED expression change must emit an alter");
+
+        assert!(
+            script.contains("drop expression"),
+            "STORED → STORED expression change still uses the in-place ALTER: {script}"
+        );
+        assert!(
+            script.contains("generated always as (id * 3) stored"),
+            "expected the new STORED expression to be re-added: {script}"
+        );
+        assert!(
+            !script.contains("drop column"),
+            "STORED expression change must not destroy the column: {script}"
         );
     }
 

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -104,11 +104,22 @@ impl TableConstraint {
 
         script.push_str(&format!("{} ", clause));
         if !self.is_enforced {
-            // Remove trailing space before appending NOT ENFORCED
-            let trimmed = script.trim_end().to_string();
-            script.clear();
-            script.push_str(&trimmed);
-            script.push_str(" not enforced ");
+            // Issue #182: PG18+ `pg_get_constraintdef()` already emits
+            // `NOT ENFORCED` for non-enforced constraints, so the
+            // lowercased deparser output flowing through `clause`
+            // already contains `not enforced`. Appending again
+            // produces `... not enforced not enforced ;`. The literal
+            // itself is `[not_enforced_keyword]` which can only appear
+            // in the keyword position, so a substring search against
+            // the (literal-preserved-case) clause is the right test.
+            // Older PG versions and PGC's own `parts.join`-built form
+            // don't include the keyword, and still need it appended.
+            if !clause.to_ascii_lowercase().contains("not enforced") {
+                let trimmed = script.trim_end().to_string();
+                script.clear();
+                script.push_str(&trimmed);
+                script.push_str(" not enforced ");
+            }
         }
         script.append_block(";");
         if let Some(ref comment) = self.comment {
@@ -714,6 +725,54 @@ mod tests {
         // Simplified behavior: just the base type
         let expected = "alter table test.persons add constraint chk_age_positive check ;\n\n";
         assert_eq!(script, expected);
+    }
+
+    #[test]
+    fn issue182_not_enforced_already_in_definition_is_not_appended_again() {
+        // PG18+ `pg_get_constraintdef()` already emits `NOT ENFORCED`
+        // in its returned string for non-enforced CHECK constraints.
+        // Without the issue-#182 fix, `get_script` would also append
+        // its own `not enforced` clause, producing the doubled
+        // `... not enforced not enforced ;` shown in the issue.
+        let mut constraint = create_check_constraint();
+        constraint.definition = Some("CHECK (price > 0::numeric) NOT ENFORCED".to_string());
+        constraint.is_enforced = false;
+
+        let script = constraint.get_script();
+
+        let count = script.matches("not enforced").count();
+        assert_eq!(
+            count, 1,
+            "`not enforced` must appear exactly once when the deparser already included it: {script}"
+        );
+        assert!(
+            script.contains("check (price > 0::numeric) not enforced"),
+            "expected the deparser-supplied keyword to survive lowercasing: {script}"
+        );
+    }
+
+    #[test]
+    fn issue182_not_enforced_appended_when_definition_omits_it() {
+        // The fix must not regress older-PG / no-deparser-keyword
+        // cases: when the source definition does NOT contain
+        // `NOT ENFORCED` and `is_enforced=false`, we still need to
+        // append the keyword so the emitted DDL reflects the desired
+        // state.
+        let mut constraint = create_check_constraint();
+        constraint.definition = Some("CHECK (price > 0::numeric)".to_string());
+        constraint.is_enforced = false;
+
+        let script = constraint.get_script();
+
+        assert!(
+            script.contains("not enforced"),
+            "expected `not enforced` to be appended when the definition omits it: {script}"
+        );
+        assert_eq!(
+            script.matches("not enforced").count(),
+            1,
+            "still must appear exactly once: {script}"
+        );
     }
 
     #[test]

--- a/app/src/dump/table_constraint.rs
+++ b/app/src/dump/table_constraint.rs
@@ -108,13 +108,17 @@ impl TableConstraint {
             // `NOT ENFORCED` for non-enforced constraints, so the
             // lowercased deparser output flowing through `clause`
             // already contains `not enforced`. Appending again
-            // produces `... not enforced not enforced ;`. The literal
-            // itself is `[not_enforced_keyword]` which can only appear
-            // in the keyword position, so a substring search against
-            // the (literal-preserved-case) clause is the right test.
-            // Older PG versions and PGC's own `parts.join`-built form
-            // don't include the keyword, and still need it appended.
-            if !clause.to_ascii_lowercase().contains("not enforced") {
+            // produces `... not enforced not enforced ;`. Older PG
+            // versions and PGC's own `parts.join`-built form don't
+            // include the keyword, and still need it appended.
+            //
+            // PR #187 review: the substring scan must skip string
+            // literals — a CHECK predicate like
+            // `CHECK (msg <> 'not enforced')` would otherwise match
+            // and silently suppress the keyword.
+            // `lowercase_outside_literals` preserves literal contents
+            // verbatim, so the literal text survives in `clause`.
+            if !Self::lowercased_contains_outside_literals(&clause, "not enforced") {
                 let trimmed = script.trim_end().to_string();
                 script.clear();
                 script.push_str(&trimmed);
@@ -210,6 +214,63 @@ impl TableConstraint {
     /// inside single-quoted string literals.  Handles the standard `''` escape
     /// for embedded quotes.  Iterates by `char` so multi-byte UTF-8 sequences
     /// are never split.
+    /// True when `needle` (must already be lowercase) appears in `s`
+    /// OUTSIDE every single-quoted string literal. Mirrors the
+    /// quote-tracking state machine used by [`Self::lowercase_outside_
+    /// literals`] so a `CHECK (msg <> 'not enforced')` predicate
+    /// doesn't get confused with the keyword position. PR #187 review
+    /// (issue #182): a plain `clause.contains("not enforced")` would
+    /// also match string literals and silently suppress the
+    /// constraint flag.
+    fn lowercased_contains_outside_literals(s: &str, needle: &str) -> bool {
+        debug_assert!(needle.chars().all(|c| !c.is_ascii_uppercase()));
+        if needle.is_empty() {
+            return true;
+        }
+        let mut buf = String::with_capacity(needle.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\'' {
+                // Skip past the literal entirely; nothing inside it
+                // counts toward keyword detection.
+                loop {
+                    match chars.next() {
+                        Some('\'') => {
+                            if chars.as_str().starts_with('\'') {
+                                chars.next(); // doubled-quote escape
+                            } else {
+                                break;
+                            }
+                        }
+                        Some(_) => {}
+                        None => return false, // unterminated literal
+                    }
+                }
+                // The literal is treated as a token boundary — flush
+                // any partial match accumulated before it.
+                buf.clear();
+                continue;
+            }
+            for lc in c.to_lowercase() {
+                buf.push(lc);
+                while !needle.starts_with(buf.as_str()) {
+                    if buf.is_empty() {
+                        break;
+                    }
+                    // Drop one char from the front and retry. Because
+                    // the haystack is searched as a stream, this
+                    // simple back-off is enough for ASCII keyword
+                    // needles like `not enforced`.
+                    buf.remove(0);
+                }
+                if buf == needle {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     fn lowercase_outside_literals(s: &str) -> String {
         let mut out = String::with_capacity(s.len());
         let mut chars = s.chars();
@@ -772,6 +833,36 @@ mod tests {
             script.matches("not enforced").count(),
             1,
             "still must appear exactly once: {script}"
+        );
+    }
+
+    #[test]
+    fn issue182_not_enforced_in_string_literal_does_not_suppress_keyword() {
+        // PR #187 review (C1): a CHECK predicate that contains the
+        // literal text `'not enforced'` must NOT cause the keyword
+        // append to be skipped — the substring is inside a string
+        // literal, not in keyword position. Without the
+        // literal-aware containment check, `is_enforced=false` would
+        // silently emit no `NOT ENFORCED` clause, changing the
+        // constraint's semantics on apply.
+        let mut constraint = create_check_constraint();
+        constraint.definition = Some("CHECK (msg <> 'not enforced')".to_string());
+        constraint.is_enforced = false;
+
+        let script = constraint.get_script();
+
+        assert!(
+            script.contains("'not enforced'"),
+            "literal contents must be preserved: {script}"
+        );
+        assert!(
+            script.trim_end().ends_with("not enforced ;") || script.contains("not enforced ;"),
+            "the keyword must still be appended despite the matching literal: {script}"
+        );
+        assert_eq!(
+            script.matches("not enforced").count(),
+            2,
+            "expected `not enforced` once inside the literal AND once as the appended keyword: {script}"
         );
     }
 

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -120,6 +120,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 - **generate_token()**: implementation changed from `gen_random_bytes` (pgcrypto) to `md5`-based
 - **get_active_usernames_sql()**: return type adds `preferred_contact` column
 - **product_price_with_tax_sql()**: new parameter `p_currency varchar DEFAULT 'USD'`
+- **cascade_compute(integer)**: return type `INTEGER` → `BIGINT` — return type change requires `DROP FUNCTION ... CASCADE` (PostgreSQL has no `ALTER FUNCTION` for return types). The argument list (`integer`) is unchanged, so the function's signature in PostgreSQL terms is identical between FROM and TO; the cascade still fires. Exercises Phase 7 of `compare_routines_and_views`, which must re-emit every dependent (CHECK / functional index / generated column / DEFAULT / RLS policy) silently dropped by CASCADE; see _CASCADE-Drop Dependent Recreation (Issue #179)_ in section 46.
 
 #### Removed Functions
 - **calculate_order_total()**: depends on removed `orders` table
@@ -433,6 +434,18 @@ Requires `wal_level = logical`. Comment out these statements if the test server 
 - **New with config**: `apply_secure_settings(IN pvalue text)` exists only in TO with `SET search_path = 'public, pg_temp'` and `SET lock_timeout = '5s'` — `CREATE OR REPLACE` with SET clauses expected
 - PostgreSQL stores these in `pg_proc.proconfig` as an array (e.g. `{search_path=public\, pg_temp,lock_timeout=5s}`)
 
+#### CASCADE-Drop Dependent Recreation (Issue #179)
+
+- `test_schema.cascade_compute(integer)` returns `INTEGER` in FROM and `BIGINT` in TO. The argument list (`integer`) is unchanged, so the routine's signature in PostgreSQL terms is identical between FROM and TO; the return-type change still requires `DROP FUNCTION ... CASCADE` (PostgreSQL has no `ALTER FUNCTION` for return types). The cascade silently removes every object whose `pg_depend` row points at the function.
+- `test_schema.cascade_items` carries one of each affected dependent kind, all referencing `cascade_compute`:
+  - **CHECK constraint**: `chk_cascade_compute CHECK (cascade_compute(value) > 0)`
+  - **Functional index**: `idx_cascade_compute ON (cascade_compute(value))`
+  - **Generated column**: `gen_col GENERATED ALWAYS AS (cascade_compute(value)) STORED`
+  - **Column DEFAULT**: `def_col … DEFAULT cascade_compute(0)`
+  - **RLS policy**: `pol_cascade_items USING (cascade_compute(value) > 0)`
+- The dependent definitions are intentionally identical (modulo the integer→bigint type bumps that follow from the new return type), so the regular table/index/policy diffs emit nothing for them. Phase 7 of `compare_routines_and_views` must re-emit each one — without it the migration leaves them missing and a second `pgc compare` run would notice the drift.
+- Generated columns are re-added via `alter table … add column` (Postgres drops generated columns wholesale on CASCADE); column DEFAULTs are restored via `alter column … set default` (the column survives, only the DEFAULT clause is dropped).
+
 ---
 
 ## Clear Command Test (`clear_test.sql`)
@@ -600,3 +613,4 @@ The comparison should detect and generate SQL for:
 - Creating, modifying, and revoking default privileges (ALTER DEFAULT PRIVILEGES per role/schema/object type)
 - Creating, modifying, and dropping foreign servers and user mappings (OPTIONS changes, add/remove entries)
 - Creating, modifying, and dropping publications (FOR TABLE list, FOR ALL TABLES, publish operations)
+- Recreating dependents silently dropped by `DROP FUNCTION ... CASCADE` when a routine is fully dropped or its return type / argument list / argument defaults change (functional indexes, CHECK constraints, generated columns, column DEFAULT expressions, RLS policies — Issue #179)

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -15,6 +15,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 
 ### 1. Schemas
 - **Added**: `new_reporting_schema` in Schema B
+- **Added**: `test_order` (issue #180 FK-ordered SET LOGGED/UNLOGGED) in both schemas — entire chain flips from LOGGED in Schema A to UNLOGGED in Schema B
 - **Unchanged**: `test_schema`, `shared_schema`
 
 ### 2. Extensions
@@ -282,6 +283,7 @@ Grant comparison test using roles `pgc_grant_reader` and `pgc_grant_writer`.
 ### 28. UNLOGGED Tables
 - **Modified**: `test_schema.unlogged_test` — regular (logged) table in FROM; UNLOGGED in TO
 - Verifies `ALTER TABLE SET UNLOGGED` / `SET LOGGED` generation
+- **FK-chain conversion (Issue #180)**: `test_order.grandparent`, `test_order.parent`, `test_order.child` — three LOGGED tables with FK chain `child -> parent -> grandparent` in Schema A; all three UNLOGGED in Schema B. Verifies the comparer emits `SET UNLOGGED` in FK-leaf-first order (`child`, then `parent`, then `grandparent`); the alphabetical order PostgreSQL would otherwise reject with `ERROR: could not change table "grandparent" to unlogged because it references logged table "parent"`. Each table's `serial` PK auto-creates an owned sequence (`*_id_seq`) — these must NOT receive an explicit `ALTER SEQUENCE ... SET UNLOGGED`, since `ALTER TABLE SET UNLOGGED` propagates to owned sequences automatically.
 
 ### 29. Storage Parameters (reloptions)
 - **Modified**: `test_schema.storage_params_test` — `fillfactor=70` in FROM; `fillfactor=90, autovacuum_enabled=false` in TO
@@ -594,7 +596,7 @@ The comparison should detect and generate SQL for:
 - Creating, dropping, and altering extended statistics (kind changes via drop+recreate)
 - Detecting NOT ENFORCED constraint flag changes (PG18+)
 - Handling virtual/stored generated column transitions (PG18+)
-- Detecting UNLOGGED ↔ LOGGED table persistence changes
+- Detecting UNLOGGED ↔ LOGGED table persistence changes, ordering `SET UNLOGGED` / `SET LOGGED` topologically over the FK graph (leaves-first / roots-first respectively) and suppressing redundant `ALTER SEQUENCE ... SET UNLOGGED|LOGGED` on owned sequences whose owning table is flipping in the same migration — PostgreSQL propagates the table change to owned sequences automatically (Issue #180)
 - Detecting storage parameters (reloptions/WITH clause) changes (fillfactor, autovacuum settings, etc.)
 - Detecting REPLICA IDENTITY changes (DEFAULT, NOTHING, FULL)
 - Detecting FORCE ROW LEVEL SECURITY changes

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -1375,3 +1375,45 @@ CREATE USER MAPPING FOR PUBLIC
 CREATE PUBLICATION test_pub_from_only FOR TABLE test_schema.users;
 CREATE PUBLICATION test_pub_unchanged FOR TABLE test_schema.users, test_schema.products;
 
+-- =============================================================================
+-- Issue #179 — DROP FUNCTION ... CASCADE recreate test (FROM side)
+-- =============================================================================
+-- Function `cascade_compute(integer)` returns INTEGER here. Schema B
+-- changes the return type to BIGINT. The argument list (`integer`) is
+-- unchanged, so the routine's signature in PostgreSQL terms is the
+-- same on both sides — but PostgreSQL has no `ALTER FUNCTION` for
+-- return types, so the comparer still emits DROP+CREATE. PostgreSQL
+-- silently CASCADE-drops every object whose `pg_depend` row points at
+-- the function: the CHECK constraint, the functional index, the
+-- generated column, the column DEFAULT, and the RLS policy. The
+-- comparer must re-emit each one (Phase 7 of
+-- `compare_routines_and_views`) — otherwise the migrated database is
+-- missing those objects until a second `pgc compare` run notices the
+-- drift.
+CREATE FUNCTION test_schema.cascade_compute(x integer)
+RETURNS integer LANGUAGE sql IMMUTABLE AS $$
+    SELECT x * 2;
+$$;
+
+CREATE TABLE test_schema.cascade_items (
+    id      serial  PRIMARY KEY,
+    value   integer NOT NULL,
+    -- DEFAULT expression depends on cascade_compute → cascaded by CASCADE
+    def_col integer DEFAULT test_schema.cascade_compute(0)::integer,
+    -- Generated column depends on cascade_compute → column dropped by CASCADE
+    gen_col integer GENERATED ALWAYS AS (test_schema.cascade_compute(value)) STORED
+);
+
+-- CHECK constraint depends on cascade_compute → cascaded by CASCADE
+ALTER TABLE test_schema.cascade_items
+    ADD CONSTRAINT chk_cascade_compute CHECK (test_schema.cascade_compute(value) > 0);
+
+-- Functional index depends on cascade_compute → cascaded by CASCADE
+CREATE INDEX idx_cascade_compute
+    ON test_schema.cascade_items (test_schema.cascade_compute(value));
+
+-- RLS policy depends on cascade_compute → cascaded by CASCADE
+ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pol_cascade_items ON test_schema.cascade_items
+    USING (test_schema.cascade_compute(value) > 0);
+

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -1417,3 +1417,43 @@ ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY pol_cascade_items ON test_schema.cascade_items
     USING (test_schema.cascade_compute(value) > 0);
 
+-- =============================================================================
+-- Issue #180 — FK-ordered SET LOGGED/UNLOGGED + redundant owned-sequence ALTER
+-- =============================================================================
+-- FROM has three LOGGED tables connected by a foreign-key chain
+-- (child -> parent -> grandparent). Schema B converts every table in
+-- the chain to UNLOGGED. The migration script must emit
+-- `ALTER TABLE ... SET UNLOGGED` in FK-leaf-first order
+-- (child -> parent -> grandparent); alphabetical order — which the
+-- comparer used before this fix — fails with:
+--   ERROR: could not change table "grandparent" to unlogged because
+--   it references logged table "parent"
+--
+-- The reverse direction (UNLOGGED -> LOGGED) requires the opposite
+-- order (roots first); both directions are exercised by the comparer's
+-- `Comparer::emit_persistence_changes` phase, which sorts each
+-- direction topologically over the FK adjacency derived from
+-- `pg_get_constraintdef`.
+--
+-- The serial PKs auto-create owned sequences. PostgreSQL propagates
+-- the table's `ALTER TABLE SET UNLOGGED` to every owned sequence
+-- automatically, so the comparer must NOT emit an explicit
+-- `ALTER SEQUENCE ... SET UNLOGGED` for them — when the only diff is
+-- `is_unlogged` and the owning table is also flipping, the entire
+-- ALTER SEQUENCE block is suppressed (issue #180).
+CREATE SCHEMA IF NOT EXISTS test_order;
+
+CREATE TABLE test_order.grandparent (
+    id serial PRIMARY KEY
+);
+
+CREATE TABLE test_order.parent (
+    id serial PRIMARY KEY,
+    grandparent_id integer REFERENCES test_order.grandparent(id)
+);
+
+CREATE TABLE test_order.child (
+    id serial PRIMARY KEY,
+    parent_id integer REFERENCES test_order.parent(id)
+);
+

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -1740,3 +1740,34 @@ CREATE INDEX idx_cascade_compute
 ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
 CREATE POLICY pol_cascade_items ON test_schema.cascade_items
     USING (test_schema.cascade_compute(value) > 0);
+
+-- =============================================================================
+-- Issue #180 — FK-ordered SET LOGGED/UNLOGGED + redundant owned-sequence ALTER
+-- =============================================================================
+-- TO mirrors Schema A's FK chain (child -> parent -> grandparent) but
+-- every table is now UNLOGGED. The comparer must emit
+-- `ALTER TABLE ... SET UNLOGGED` in FK-leaf-first order
+-- (child, then parent, then grandparent) — alphabetical order rejects
+-- with:
+--   ERROR: could not change table "grandparent" to unlogged because
+--   it references logged table "parent"
+--
+-- The serial PKs auto-create owned sequences (`*_id_seq`). PostgreSQL
+-- propagates the table's `ALTER TABLE SET UNLOGGED` to every owned
+-- sequence on its own, so no explicit `ALTER SEQUENCE ... SET
+-- UNLOGGED` should appear for those sequences in the migration.
+CREATE SCHEMA IF NOT EXISTS test_order;
+
+CREATE UNLOGGED TABLE test_order.grandparent (
+    id serial PRIMARY KEY
+);
+
+CREATE UNLOGGED TABLE test_order.parent (
+    id serial PRIMARY KEY,
+    grandparent_id integer REFERENCES test_order.grandparent(id)
+);
+
+CREATE UNLOGGED TABLE test_order.child (
+    id serial PRIMARY KEY,
+    parent_id integer REFERENCES test_order.parent(id)
+);

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -1697,3 +1697,46 @@ CREATE USER MAPPING FOR PUBLIC
 -- test_pub_from_only: removed; test_pub_unchanged: same as FROM; test_pub_to_only: added
 CREATE PUBLICATION test_pub_unchanged FOR TABLE test_schema.users, test_schema.products;
 CREATE PUBLICATION test_pub_to_only FOR ALL TABLES;
+
+-- =============================================================================
+-- Issue #179 — DROP FUNCTION ... CASCADE recreate test (TO side)
+-- =============================================================================
+-- Function `cascade_compute(integer)` returns BIGINT here (was INTEGER in
+-- Schema A). The argument list (`integer`) is unchanged, so the
+-- routine's signature in PostgreSQL terms is identical to FROM; only
+-- the return type differs. PostgreSQL has no `ALTER FUNCTION` for
+-- return types, so the comparer still emits `DROP FUNCTION ... CASCADE`,
+-- which silently removes the CHECK / functional index / generated column
+-- / column DEFAULT / RLS policy below — every dependent that
+-- `pg_depend` connects to the function. Phase 7 of
+-- `compare_routines_and_views` must re-emit each one. The dependent
+-- definitions below are intentionally identical (modulo the integer→
+-- bigint type bumps that follow from the new return type) to FROM, so
+-- the regular table/index/policy diffs would emit nothing for them —
+-- without Phase 7 the migration would leave them missing.
+CREATE FUNCTION test_schema.cascade_compute(x integer)
+RETURNS bigint LANGUAGE sql IMMUTABLE AS $$
+    SELECT (x * 2)::bigint;
+$$;
+
+CREATE TABLE test_schema.cascade_items (
+    id      serial  PRIMARY KEY,
+    value   integer NOT NULL,
+    -- def_col type bumped integer → bigint to match the new return type;
+    -- the DEFAULT itself is still cascaded by DROP FUNCTION ... CASCADE.
+    def_col bigint  DEFAULT test_schema.cascade_compute(0),
+    -- gen_col type bumped integer → bigint; the column itself is
+    -- cascaded by DROP FUNCTION ... CASCADE (Postgres drops generated
+    -- columns wholesale, not just their expression) and must be re-added.
+    gen_col bigint  GENERATED ALWAYS AS (test_schema.cascade_compute(value)) STORED
+);
+
+ALTER TABLE test_schema.cascade_items
+    ADD CONSTRAINT chk_cascade_compute CHECK (test_schema.cascade_compute(value) > 0);
+
+CREATE INDEX idx_cascade_compute
+    ON test_schema.cascade_items (test_schema.cascade_compute(value));
+
+ALTER TABLE test_schema.cascade_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pol_cascade_items ON test_schema.cascade_items
+    USING (test_schema.cascade_compute(value) > 0);


### PR DESCRIPTION
Bug fixes:
  - Fixed issue #182 (PG18 NOT ENFORCED CHECK constraints): `TableConstraint::get_script` was appending its own ` not enforced ` clause even when the deparser-supplied `definition` already ended in `NOT ENFORCED`. PG18+ `pg_get_constraintdef()` includes the keyword when the constraint is non-enforced, so the generated SQL came out as `… not enforced not enforced ;`. PostgreSQL accepts the duplicate idempotently so it never failed at runtime, but the output was wrong. The fix only appends the keyword when the `clause` (case-insensitively) doesn't already contain it; older-PG dumps and the keyword-less `parts.join`-built path keep working.
  - Fixed issue #181 (PG18 virtual generated columns): a STORED ↔ VIRTUAL flip with the same generation expression produced no script at all, because `TableColumn::get_alter_script`'s `generated_changed` predicate only considered `is_generated` and `generation_expression` and ignored `generation_type`. Now compares `effective_generation_type` as well, so the flip is detected. And a virtual generated column with a changed expression used to emit `ALTER COLUMN DROP EXPRESSION` + `ALTER COLUMN ADD GENERATED ALWAYS AS (...) VIRTUAL`, both of which PG18 rejects (DROP EXPRESSION is STORED-only; the ADD GENERATED form has no VIRTUAL variant). The fix routes every VIRTUAL participant — flips of `generation_type` in either direction, and expression changes on a VIRTUAL column — through the full `DROP COLUMN` + `ADD COLUMN ... GENERATED ALWAYS AS (...) VIRTUAL|STORED` round-trip, which is the only valid migration PG18 accepts. STORED → STORED expression changes keep the cheaper in-place `DROP EXPRESSION` + `ADD GENERATED ... STORED` form.
  - Fixed issue #180: `ALTER TABLE ... SET LOGGED| UNLOGGED` was emitted inline with the per-table alter loop in alphabetical order, which PostgreSQL rejects whenever an FK chain flips persistence in the same migration — `SET UNLOGGED` fails if any LOGGED table references the target, `SET LOGGED` fails if the target references any UNLOGGED one. Moved the emission out of `Table::build_alter_script` and into a dedicated `Comparer::emit_persistence_ changes` phase that runs at the end of `compare_tables`: tables flipping to UNLOGGED are sorted leaves-before-roots (reverse FK topo), tables flipping to LOGGED are sorted roots-before-leaves (forward FK topo), each via `Self::topo_order_within_subset` over an FK adjacency derived from the TO-side constraint definitions (parsed by `Self::parse_fk_ referenced_table`). Owned sequences also get cleaner output: `Sequence::is_only_persistence_ change` lets `compare_sequences` skip the entire `ALTER SEQUENCE` for sequences whose only diff is `is_unlogged` and whose owning table is itself flipping persistence (PostgreSQL propagates the `ALTER TABLE SET LOGGED|UNLOGGED` to every owned sequence automatically, so the explicit emit was redundant), and `Sequence::get_alter_script_ excluding_persistence` strips just the `ALTER SEQUENCE … SET LOGGED|UNLOGGED` line when the sequence has other diffs to emit but the owning table will still propagate the persistence flip.
  - Fixed issue #179: when a routine was dropped or its return type / arguments / argument defaults changed, `DROP FUNCTION ... CASCADE` silently removed every dependent linked through `pg_depend` — functional indexes, CHECK constraints, generated columns, column DEFAULTs, and RLS policies — and the comparer never re-emitted them, leaving the database missing those objects until a second `pgc compare` run. Added Phase 7 to `Comparer::compare_routines_and_views`: after the affected functions are recreated, restore each cascaded dependent from its TO-side definition. Generated columns and indexes use non-destructive `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`; constraints, policies, and DEFAULTs use idempotent `drop ... if exists` + create or `alter column set default`. The phase honours multiple safety gates: partition-child rules (skip inherited constraints, partition-inherited indexes, and all structural column changes — truly-local child constraints still re-emit); qualified and unqualified detection (deparsers drop the schema qualifier when the function is in `search_path`, both forms must require a `(` call gate so `ON schema.table` / `nextval(... :: regclass)` don't false-positive); UTF-8 boundary walking via `match_indices` for non-ASCII identifiers (`"русское_имя"`); quote-stripped affected-routine names so `quote_ident`-wrapped `"MyFunc"` matches the deparsed `myfunc(`; and a TO-side reference check so dependents already rewritten by `compare_tables()` are left alone (the broken `pg_depend` link means CASCADE leaves them intact, and the IF NOT EXISTS forms make the false-positive case a runtime no-op rather than a destructive drop — overloaded routines collapse together in the text matcher and would otherwise cascade-destroy unrelated indexes / FKs / constraints attached to a still-present column). `Routine::hash()` now includes `arguments_defaults` so a defaults-only change actually triggers DROP+CREATE (PostgreSQL has no in-place `ALTER FUNCTION` for default values). Note: a v1.0.19 dump compared against a v1.0.20 dump may flag every routine carrying defaults as changed even when the body is identical; rebuild the FROM dump under v1.0.20 to suppress the noise.
