### PR TITLE
#189

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,37 @@
 2026-05-14      v1.0.21
 
+                Bug fixes:
+                    - Fixed issue #189 (Phase 7 doesn't recreate
+                      views silently dropped by `DROP FUNCTION ...
+                      CASCADE`). PR #183's Phase 7 restored functional
+                      indexes, CHECK constraints, generated columns,
+                      column DEFAULTs, and RLS policies after a
+                      CASCADE drop, but skipped views — a view whose
+                      definition referenced the cascaded routine and
+                      was byte-identical between FROM and TO had its
+                      hash matched in
+                      `compare_routines_and_views`, was never
+                      re-emitted, and disappeared from the database
+                      until a second `pgc compare` run noticed the
+                      drift. Extended
+                      `Comparer::recreate_routine_dependents` with a
+                      view scan that runs `definition_references_any`
+                      over `from_view.definition`, applies the same
+                      TO-side gate (PR #186) against
+                      `to_view.definition` so views already rewritten
+                      by another phase are left alone, and skips views
+                      already present in `dropped_views` (Phase 5
+                      handles those via the drop-and-recreate path).
+                      Regular views emit `CREATE OR REPLACE VIEW`
+                      (idempotent: no-op if the view survived CASCADE,
+                      a real create if it did not); materialized views
+                      emit `CREATE MATERIALIZED VIEW IF NOT EXISTS`
+                      for the same reason — Phase 7's text-based
+                      matcher can false-positive on a view that
+                      PostgreSQL never actually dropped, and an
+                      unconditional CREATE would fail against a
+                      surviving view.
+
                 Enhancements:
                     - Resolved issue #192 (separate tests into
                       `_tests.rs` files): every dump/, comparer/,

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -2537,17 +2537,7 @@ impl Comparer {
                 self.script.push_str(&to_view.get_script());
             }
         } else {
-            let mut view_script = to_view.get_script();
-            if !view_script
-                .to_uppercase()
-                .contains("CREATE OR REPLACE VIEW")
-            {
-                const TARGET: &str = "create view";
-                const REPLACEMENT: &str = "CREATE OR REPLACE VIEW";
-                if let Some(pos) = view_script.to_ascii_lowercase().find(TARGET) {
-                    view_script.replace_range(pos..pos + TARGET.len(), REPLACEMENT);
-                }
-            }
+            let view_script = rewrite_create_view_to_create_or_replace(&to_view.get_script());
             let normalized_view = Self::normalized_view_key(&to_view.schema, &to_view.name);
             let drop_was_active = self
                 .dropped_views
@@ -4893,20 +4883,22 @@ fn view_recreate_block(view: &View) -> String {
 }
 
 /// Rewrites the lowercase `create view ` prefix produced by
-/// `View::get_script` to `CREATE OR REPLACE VIEW `. If the script
-/// already contains `CREATE OR REPLACE VIEW` (e.g. an upstream rewrite)
-/// the script is returned unchanged.
+/// `View::get_script` to `CREATE OR REPLACE VIEW `. The check is
+/// anchored to the start of the script via `strip_prefix` rather than a
+/// whole-script `contains` / `find` scan: the view definition body
+/// `View::get_script` appends after the prefix can legitimately contain
+/// the literal text `create view` or `CREATE OR REPLACE VIEW` (e.g. a
+/// string literal in the select list), and a non-anchored matcher would
+/// either false-positive on the early-return branch (leaving the
+/// leading `create view` unrewritten) or rewrite a non-prefix
+/// occurrence. If the script already starts with `CREATE OR REPLACE
+/// VIEW` (upstream rewrite) or some other unanticipated leading form,
+/// it is returned unchanged.
 fn rewrite_create_view_to_create_or_replace(script: &str) -> String {
-    if script.to_uppercase().contains("CREATE OR REPLACE VIEW") {
-        return script.to_string();
+    if let Some(rest) = script.strip_prefix("create view ") {
+        return format!("CREATE OR REPLACE VIEW {}", rest);
     }
-    const TARGET: &str = "create view";
-    const REPLACEMENT: &str = "CREATE OR REPLACE VIEW";
-    let mut out = script.to_string();
-    if let Some(pos) = out.to_ascii_lowercase().find(TARGET) {
-        out.replace_range(pos..pos + TARGET.len(), REPLACEMENT);
-    }
-    out
+    script.to_string()
 }
 
 /// Rewrites the lowercase `create materialized view ` prefix produced by

--- a/app/src/comparer/core.rs
+++ b/app/src/comparer/core.rs
@@ -3620,9 +3620,10 @@ impl Comparer {
         // `DROP ... CASCADE` and PostgreSQL removes every object whose
         // `pg_depend` entry points at that function: functional indexes,
         // CHECK constraints, generated columns, column DEFAULT
-        // expressions and RLS policies. The rest of the comparer never
-        // re-emits those dependents because they were unchanged between
-        // FROM and TO. See issue #179.
+        // expressions, RLS policies and views (regular + materialized).
+        // The rest of the comparer never re-emits those dependents
+        // because they were unchanged between FROM and TO. See issues
+        // #179 (non-view dependents) and #189 (views).
         self.recreate_routine_dependents();
 
         self.script
@@ -3633,14 +3634,15 @@ impl Comparer {
     /// Re-emit objects that PostgreSQL silently dropped via
     /// `DROP FUNCTION ... CASCADE` so they are present in the database
     /// after the migration applies. Targets functional indexes, CHECK
-    /// constraints, generated columns, column DEFAULT expressions and
-    /// RLS policies that reference any routine being dropped+recreated
-    /// or fully dropped. Detection is text-based against the FROM-side
-    /// definition; the recreated form comes from TO so any reshape of
-    /// the dependent (e.g. a column type change) is preserved. Issued
-    /// statements are idempotent (`drop ... if exists` followed by the
-    /// CREATE) so they are safe even when other diff phases also
-    /// emitted the object.
+    /// constraints, generated columns, column DEFAULT expressions, RLS
+    /// policies and views (regular + materialized) that reference any
+    /// routine being dropped+recreated or fully dropped. Detection is
+    /// text-based against the FROM-side definition; the recreated form
+    /// comes from TO so any reshape of the dependent (e.g. a column
+    /// type change) is preserved. Issued statements are idempotent
+    /// (`drop ... if exists` followed by the CREATE, or `CREATE OR
+    /// REPLACE` / `IF NOT EXISTS` for views) so they are safe even
+    /// when other diff phases also emitted the object.
     fn recreate_routine_dependents(&mut self) {
         // Collect (schema_lc, name_lc) for every routine whose drop will
         // CASCADE: routines absent from TO, plus routines whose signature
@@ -3996,6 +3998,53 @@ impl Comparer {
                     &policy_recreate_block(to_policy),
                 );
             }
+        }
+
+        // Views (regular and materialized) whose definition references an
+        // affected routine are also CASCADE-dropped by PostgreSQL — issue
+        // #189 / PR #187 review. The hash check in
+        // `compare_routines_and_views` skips byte-identical views, so this
+        // is the only place where an unchanged view referencing a
+        // signature-changed function gets re-emitted.
+        let to_view_by_id: HashMap<(&str, &str), &View> = self
+            .to
+            .views
+            .iter()
+            .map(|v| ((v.schema.as_str(), v.name.as_str()), v))
+            .collect();
+
+        for from_view in &self.from.views {
+            if !Self::definition_references_any(&from_view.definition, &affected) {
+                continue;
+            }
+            let Some(to_view) =
+                to_view_by_id.get(&(from_view.schema.as_str(), from_view.name.as_str()))
+            else {
+                continue;
+            };
+            // TO-side gate: if the TO definition no longer references the
+            // affected routine, `compare_tables`/Phase 5 has already
+            // rewritten the view or its function dependency is gone — the
+            // CASCADE leaves it intact (or another phase re-emits it).
+            if !Self::definition_references_any(&to_view.definition, &affected) {
+                continue;
+            }
+            // Phase 5 already emits the view when `dropped_views`
+            // contains it (drop-and-recreate path triggered by a
+            // referenced table changing) — don't duplicate that work.
+            let normalized_view = Self::normalized_view_key(&to_view.schema, &to_view.name);
+            if self.dropped_views.contains_key(&normalized_view) {
+                continue;
+            }
+            let key = format!("view:{}.{}", to_view.schema, to_view.name);
+            if !emitted_keys.insert(key) {
+                continue;
+            }
+            Self::emit_dependent_recreate(
+                &mut recreate,
+                self.use_drop,
+                &view_recreate_block(to_view),
+            );
         }
 
         if !recreate.is_empty() {
@@ -4824,6 +4873,52 @@ fn inject_if_not_exists_into_create_index(script: &str) -> String {
 /// is safe and unambiguous.
 fn inject_if_not_exists_into_add_column(script: &str) -> String {
     script.replacen("add column ", "add column if not exists ", 1)
+}
+
+/// Idempotent recreate block for a view that may have been silently
+/// dropped by `DROP FUNCTION ... CASCADE`. Regular views use
+/// `CREATE OR REPLACE VIEW` (a no-op when the view still exists with the
+/// same definition; a create when CASCADE removed it). Materialized
+/// views use `CREATE MATERIALIZED VIEW IF NOT EXISTS` for the same
+/// reason — Phase 7's text-based matching can false-positive on a view
+/// that PostgreSQL never actually dropped, and an unconditional CREATE
+/// would fail against a surviving view.
+fn view_recreate_block(view: &View) -> String {
+    let script = view.get_script();
+    if view.is_materialized {
+        inject_if_not_exists_into_create_materialized_view(&script)
+    } else {
+        rewrite_create_view_to_create_or_replace(&script)
+    }
+}
+
+/// Rewrites the lowercase `create view ` prefix produced by
+/// `View::get_script` to `CREATE OR REPLACE VIEW `. If the script
+/// already contains `CREATE OR REPLACE VIEW` (e.g. an upstream rewrite)
+/// the script is returned unchanged.
+fn rewrite_create_view_to_create_or_replace(script: &str) -> String {
+    if script.to_uppercase().contains("CREATE OR REPLACE VIEW") {
+        return script.to_string();
+    }
+    const TARGET: &str = "create view";
+    const REPLACEMENT: &str = "CREATE OR REPLACE VIEW";
+    let mut out = script.to_string();
+    if let Some(pos) = out.to_ascii_lowercase().find(TARGET) {
+        out.replace_range(pos..pos + TARGET.len(), REPLACEMENT);
+    }
+    out
+}
+
+/// Rewrites the lowercase `create materialized view ` prefix produced by
+/// `View::get_script` to `create materialized view if not exists `. The
+/// prefix is generated by us in known lowercase form so a single
+/// `replacen` against the first hit is safe and unambiguous.
+fn inject_if_not_exists_into_create_materialized_view(script: &str) -> String {
+    script.replacen(
+        "create materialized view ",
+        "create materialized view if not exists ",
+        1,
+    )
 }
 
 /// `drop policy if exists` + `create policy` block from the TO-side policy.

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -9278,3 +9278,215 @@ fn issue180_sequence_only_persistence_change_uses_hash_diff() {
         "a hashed field difference must block the persistence-only suppression"
     );
 }
+
+/// Build a view whose definition textually references `test_deps.compute`.
+/// Returns a regular or materialized view depending on `is_materialized`.
+fn issue189_view(name: &str, is_materialized: bool) -> View {
+    let mut view = View::new(
+        name.to_string(),
+        " SELECT test_deps.compute(value) AS c\n   FROM test_deps.items;".to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    view.is_materialized = is_materialized;
+    view.hash();
+    view
+}
+
+#[tokio::test]
+async fn issue189_signature_change_recreates_byte_identical_view() {
+    // The view's hash is unchanged between FROM and TO, but the function
+    // it references undergoes a signature change (integer → bigint),
+    // forcing DROP FUNCTION ... CASCADE. PostgreSQL silently drops the
+    // view as part of the cascade. Phase 7 must re-emit the view so the
+    // migration leaves the database in a consistent state.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.views.push(issue189_view("v_things", false));
+    to_dump.views.push(issue189_view("v_things", false));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    let drop_pos = script
+        .find("drop function if exists test_deps.compute (x integer) cascade;")
+        .expect("CASCADE drop must be emitted for the signature change");
+    let create_fn_pos = script
+        .find("create or replace function test_deps.compute(x integer) returns bigint")
+        .expect("function recreate must be emitted");
+    assert!(drop_pos < create_fn_pos);
+
+    let view_pos = script
+        .find("CREATE OR REPLACE VIEW test_deps.v_things")
+        .expect("byte-identical view must be re-emitted as CREATE OR REPLACE VIEW after CASCADE");
+    assert!(
+        create_fn_pos < view_pos,
+        "view recreate must run after the function recreate so the new signature is in place"
+    );
+}
+
+#[tokio::test]
+async fn issue189_signature_change_recreates_byte_identical_materialized_view() {
+    // Same scenario as the regular-view case but with a materialized
+    // view. PostgreSQL CASCADE drops these via `pg_depend` the same way,
+    // so Phase 7 must emit a `create materialized view if not exists`.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.views.push(issue189_view("mv_things", true));
+    to_dump.views.push(issue189_view("mv_things", true));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("create materialized view if not exists test_deps.mv_things"),
+        "materialized view must be re-emitted with IF NOT EXISTS: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue189_view_not_referencing_routine_is_not_recreated() {
+    // A view that doesn't textually reference the CASCADE-affected
+    // routine must be left alone — re-emitting it would clutter the
+    // migration and could re-introduce a stale definition if the user
+    // has the same view in both dumps for unrelated reasons.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    let mut unrelated_from = View::new(
+        "v_other".to_string(),
+        " SELECT value FROM test_deps.items;".to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    unrelated_from.hash();
+    let mut unrelated_to = View::new(
+        "v_other".to_string(),
+        " SELECT value FROM test_deps.items;".to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    unrelated_to.hash();
+    from_dump.views.push(unrelated_from);
+    to_dump.views.push(unrelated_to);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("v_other"),
+        "view that doesn't reference the cascaded routine must not be re-emitted: {}",
+        script
+    );
+}
+
+#[tokio::test]
+async fn issue189_view_recreate_skipped_when_to_definition_no_longer_references_routine() {
+    // TO-side gate (PR #186): if the TO view's definition was rewritten
+    // to no longer call the affected routine, the CASCADE drop never
+    // touches it (no pg_depend link). `compare_routines_and_views`
+    // already emits the rewrite via the normal hash-diff path; Phase 7
+    // must stay silent so we don't re-emit the view twice.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    from_dump.views.push(issue189_view("v_things", false));
+    // TO view: same name, but the definition no longer references the
+    // function — different hash, so Phase 5 handles it.
+    let mut to_view = View::new(
+        "v_things".to_string(),
+        " SELECT value AS c FROM test_deps.items;".to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    to_view.hash();
+    to_dump.views.push(to_view);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    // The view must appear exactly once (the normal hash-diff path), not
+    // a second time from Phase 7's recreate block.
+    let recreate_section_start = script.find("Recreate dependents dropped by CASCADE: Start");
+    if let Some(start) = recreate_section_start {
+        let recreate_end = script[start..]
+            .find("Recreate dependents dropped by CASCADE: End")
+            .map(|e| start + e)
+            .unwrap_or(script.len());
+        let recreate_section = &script[start..recreate_end];
+        assert!(
+            !recreate_section.contains("v_things"),
+            "Phase 7 must not re-emit a view whose TO definition no longer references the routine: {}",
+            recreate_section
+        );
+    }
+}
+
+#[tokio::test]
+async fn issue189_view_recreate_skipped_when_routine_unchanged() {
+    // No CASCADE — no recreate. Mirrors
+    // `issue179_recreate_skipped_when_routine_unchanged` for views.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    let routine = issue179_compute_routine("integer", "SELECT x * 2;");
+    from_dump.routines.push(routine.clone());
+    to_dump.routines.push(routine);
+
+    from_dump.views.push(issue189_view("v_things", false));
+    to_dump.views.push(issue189_view("v_things", false));
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        !script.contains("Recreate dependents dropped by CASCADE"),
+        "no CASCADE drop happened — recreate phase must stay silent: {}",
+        script
+    );
+    assert!(
+        !script.contains("CREATE OR REPLACE VIEW test_deps.v_things"),
+        "view must not be re-emitted when the function is unchanged: {}",
+        script
+    );
+}

--- a/app/src/comparer/core_tests.rs
+++ b/app/src/comparer/core_tests.rs
@@ -9461,6 +9461,84 @@ async fn issue189_view_recreate_skipped_when_to_definition_no_longer_references_
     }
 }
 
+#[test]
+fn issue189_rewrite_create_view_anchored_to_prefix() {
+    // PR #195 review (Copilot): the helper must not be fooled by the
+    // literal text `CREATE OR REPLACE VIEW` appearing inside the view
+    // definition body that `View::get_script` appends after the
+    // `create view` prefix. A whole-script `contains` early-return
+    // would skip the rewrite and leave the leading `create view`
+    // unchanged, which is not idempotent against a surviving view.
+    let script = "create view public.v_with_literal as\n\
+                  SELECT 'CREATE OR REPLACE VIEW pretend.v AS SELECT 1' AS payload;\n\n";
+    let rewritten = rewrite_create_view_to_create_or_replace(script);
+    assert!(
+        rewritten.starts_with("CREATE OR REPLACE VIEW public.v_with_literal as\n"),
+        "leading `create view` must be rewritten even when the body \
+         contains the same phrase as a string literal: {}",
+        rewritten
+    );
+    // Already in the desired form — return unchanged (no double rewrite).
+    let already = "CREATE OR REPLACE VIEW public.v as\nSELECT 1;\n";
+    assert_eq!(rewrite_create_view_to_create_or_replace(already), already);
+}
+
+#[tokio::test]
+async fn issue189_view_definition_with_create_or_replace_literal_is_recreated() {
+    // End-to-end pin for the PR #195 reviewer concern: a view whose
+    // definition embeds the literal text `CREATE OR REPLACE VIEW` must
+    // still emit a properly idempotent `CREATE OR REPLACE VIEW` prefix
+    // when Phase 7 re-emits it after a CASCADE drop.
+    let mut from_dump = Dump::new(DumpConfig::default());
+    let mut to_dump = Dump::new(DumpConfig::default());
+
+    from_dump
+        .routines
+        .push(issue179_compute_routine("integer", "SELECT x * 2;"));
+    to_dump.routines.push(issue179_compute_routine(
+        "bigint",
+        "SELECT (x * 2)::bigint;",
+    ));
+
+    let definition = " SELECT test_deps.compute(value) AS c,\n        \
+                      'CREATE OR REPLACE VIEW evil.v AS SELECT 1' AS payload\n   \
+                      FROM test_deps.items;";
+    let mut from_view = View::new(
+        "v_things".to_string(),
+        definition.to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    from_view.hash();
+    let mut to_view = View::new(
+        "v_things".to_string(),
+        definition.to_string(),
+        "test_deps".to_string(),
+        vec!["test_deps.items".to_string()],
+    );
+    to_view.hash();
+    from_dump.views.push(from_view);
+    to_dump.views.push(to_view);
+
+    let mut comparer = Comparer::new(from_dump, to_dump, true, false, true, GrantsMode::Ignore);
+    comparer.compare_routines_and_views().await.unwrap();
+    let script = comparer.get_script();
+
+    assert!(
+        script.contains("CREATE OR REPLACE VIEW test_deps.v_things"),
+        "view recreate must emit `CREATE OR REPLACE VIEW` at the leading \
+         statement even when the body contains the same phrase: {}",
+        script
+    );
+    // The body's literal must survive unchanged — we do NOT want a
+    // rewrite that mangles a non-prefix occurrence.
+    assert!(
+        script.contains("'CREATE OR REPLACE VIEW evil.v AS SELECT 1'"),
+        "literal inside the view body must be left intact: {}",
+        script
+    );
+}
+
 #[tokio::test]
 async fn issue189_view_recreate_skipped_when_routine_unchanged() {
     // No CASCADE — no recreate. Mirrors


### PR DESCRIPTION
Bug fixes:
  - Fixed issue #189 (Phase 7 doesn't recreate views silently dropped by `DROP FUNCTION ... CASCADE`). PR #183's Phase 7 restored functional indexes, CHECK constraints, generated columns, column DEFAULTs, and RLS policies after a CASCADE drop, but skipped views — a view whose definition referenced the cascaded routine and was byte-identical between FROM and TO had its hash matched in `compare_routines_and_views`, was never re-emitted, and disappeared from the database until a second `pgc compare` run noticed the drift. Extended `Comparer::recreate_routine_dependents` with a view scan that runs `definition_references_any` over `from_view.definition`, applies the same TO-side gate (PR #186) against `to_view.definition` so views already rewritten by another phase are left alone, and skips views already present in `dropped_views` (Phase 5 handles those via the drop-and-recreate path). Regular views emit `CREATE OR REPLACE VIEW` (idempotent: no-op if the view survived CASCADE, a real create if it did not); materialized views emit `CREATE MATERIALIZED VIEW IF NOT EXISTS` for the same reason — Phase 7's text-based matcher can false-positive on a view that PostgreSQL never actually dropped, and an unconditional CREATE would fail against a surviving view.
