### PR TITLE
223 create index on partitioned table uses on only without completing partition attachment leaving index invalid

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,6 +172,28 @@ jobs:
         psql -h 127.0.0.1 -U postgres -d a -v ON_ERROR_STOP=0 \
           -f /tmp/output.sql
 
+    - name: Assert all indexes are valid
+      env:
+        PGPASSWORD: postgres
+      run: |
+        # An index on a partitioned parent emitted as `CREATE INDEX ... ON ONLY`
+        # without the per-partition attach sequence stays indisvalid=false
+        # (issue #223). The round-2 diff cannot catch it — the invalid index
+        # still exists, so the compare is empty — so assert directly that no
+        # index the migration produced was left invalid.
+        invalid=$(psql -h 127.0.0.1 -U postgres -d a -tAc \
+          "select string_agg(format('%I.%I', n.nspname, c.relname), ', ')
+           from pg_index x
+           join pg_class c on c.oid = x.indexrelid
+           join pg_namespace n on n.oid = c.relnamespace
+           where not x.indisvalid
+             and n.nspname not in ('pg_catalog', 'information_schema');")
+        if [ -n "${invalid}" ]; then
+          echo "ERROR: invalid indexes after applying the migration on PG ${{ matrix.pg_version }}: ${invalid}"
+          exit 1
+        fi
+        echo "OK: all indexes valid on PG ${{ matrix.pg_version }}"
+
     - name: Run pgc compare (round 2) — must be empty
       run: |
         ./app/target/release/pgc --config /tmp/pgc.conf

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,25 @@
 2026-07-17      v1.0.25
 
                 Bug fixes:
+                    - Resolved issue #223 (CREATE INDEX on a
+                      partitioned table used ON ONLY without attaching
+                      the partition indexes, leaving the index
+                      invalid). pg_get_indexdef renders a partitioned
+                      parent's index with ON ONLY, which creates only
+                      the metadata index on the parent and leaves it
+                      indisvalid=false until every partition's index is
+                      built and attached. The default output emitted
+                      that ON ONLY form verbatim with no attach step,
+                      so the resulting index was permanently invalid
+                      and no partition indexes were created. The
+                      non-production output now emits a plain CREATE
+                      INDEX ... ON, so PostgreSQL builds and attaches
+                      the partition indexes itself and the parent index
+                      is valid immediately. Production output
+                      (OUTPUT_FOR_PRODUCTION=true) is unchanged: it
+                      still emits ON ONLY followed by the per-partition
+                      CREATE INDEX CONCURRENTLY and ATTACH PARTITION
+                      sequence.
                     - Resolved issue #218 (spurious DROP CONSTRAINT
                       and ADD CONSTRAINT for inline NOT NULL). A
                       column's inline NOT NULL is surfaced by

--- a/app/src/dump/table_index.rs
+++ b/app/src/dump/table_index.rs
@@ -18,6 +18,28 @@ pub struct TableIndex {
     pub comment: Option<String>,
 }
 
+/// Drop the `ONLY` from an index definition's `ON ONLY <table>` target.
+///
+/// `pg_get_indexdef` renders a partitioned parent's index with `ON ONLY`, which
+/// creates only the metadata index on the parent and leaves it `indisvalid = false`
+/// until every partition's index is built and attached. The default (non-production)
+/// output has no attach step, so it must emit a plain `CREATE INDEX ... ON <table>`:
+/// PostgreSQL then builds and attaches the partition indexes itself and the parent
+/// index is valid immediately. A definition without `ON ONLY` (every non-partitioned
+/// index) is returned unchanged. The production path builds its own `ON ONLY` form
+/// with the concurrent per-partition attach sequence (see `comparer::production`) and
+/// does not go through here.
+fn strip_on_only(indexdef: &str) -> String {
+    let Some(pos) = indexdef.find(" ON ") else {
+        return indexdef.to_string();
+    };
+    let after = &indexdef[pos + " ON ".len()..];
+    match after.strip_prefix("ONLY ") {
+        Some(rest) => format!("{} ON {}", &indexdef[..pos], rest),
+        None => indexdef.to_string(),
+    }
+}
+
 impl TableIndex {
     /// Hash
     pub fn add_to_hasher(&self, hasher: &mut Sha256) {
@@ -34,7 +56,7 @@ impl TableIndex {
     /// Returns a string representation of the index
     pub fn get_script(&self) -> String {
         let mut script = String::new();
-        script.push_str(&self.indexdef);
+        script.push_str(&strip_on_only(&self.indexdef));
         script.append_block(";");
         if let Some(comment) = &self.comment {
             script.append_block(&format!(

--- a/app/src/dump/table_index.rs
+++ b/app/src/dump/table_index.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -26,17 +28,18 @@ pub struct TableIndex {
 /// output has no attach step, so it must emit a plain `CREATE INDEX ... ON <table>`:
 /// PostgreSQL then builds and attaches the partition indexes itself and the parent
 /// index is valid immediately. A definition without `ON ONLY` (every non-partitioned
-/// index) is returned unchanged. The production path builds its own `ON ONLY` form
-/// with the concurrent per-partition attach sequence (see `comparer::production`) and
-/// does not go through here.
-fn strip_on_only(indexdef: &str) -> String {
+/// index — the common case) is borrowed unchanged, so only the rare partitioned-parent
+/// rewrite allocates. The production path builds its own `ON ONLY` form with the
+/// concurrent per-partition attach sequence (see `comparer::production`) and does not
+/// go through here.
+fn strip_on_only(indexdef: &str) -> Cow<'_, str> {
     let Some(pos) = indexdef.find(" ON ") else {
-        return indexdef.to_string();
+        return Cow::Borrowed(indexdef);
     };
     let after = &indexdef[pos + " ON ".len()..];
     match after.strip_prefix("ONLY ") {
-        Some(rest) => format!("{} ON {}", &indexdef[..pos], rest),
-        None => indexdef.to_string(),
+        Some(rest) => Cow::Owned(format!("{} ON {}", &indexdef[..pos], rest)),
+        None => Cow::Borrowed(indexdef),
     }
 }
 

--- a/app/src/dump/table_index_tests.rs
+++ b/app/src/dump/table_index_tests.rs
@@ -233,6 +233,74 @@ fn test_get_script_partial_index() {
     assert_eq!(script, expected);
 }
 
+// Issue #223: pg_get_indexdef renders a partitioned parent's index with `ON ONLY`,
+// which creates only the invalid metadata index. The default (non-production) output
+// must emit a plain `CREATE INDEX ... ON` so PostgreSQL builds and attaches every
+// partition's index and the parent index is valid immediately.
+#[test]
+fn test_get_script_strips_on_only_for_partitioned_parent() {
+    let index = TableIndex {
+        schema: "t".to_string(),
+        table: "events".to_string(),
+        name: "ix_events_event_type".to_string(),
+        catalog: None,
+        indexdef: "CREATE INDEX ix_events_event_type ON ONLY t.events USING btree (event_type)"
+            .to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+    assert_eq!(
+        index.get_script(),
+        "CREATE INDEX ix_events_event_type ON t.events USING btree (event_type);\n\n"
+    );
+}
+
+#[test]
+fn test_get_script_strips_on_only_for_unique_partitioned_parent() {
+    let index = TableIndex {
+        schema: "t".to_string(),
+        table: "events".to_string(),
+        name: "uq_events_id".to_string(),
+        catalog: None,
+        indexdef: "CREATE UNIQUE INDEX uq_events_id ON ONLY t.events USING btree (id)".to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+    assert_eq!(
+        index.get_script(),
+        "CREATE UNIQUE INDEX uq_events_id ON t.events USING btree (id);\n\n"
+    );
+}
+
+// A non-partitioned index never carries `ON ONLY`, so it must pass through untouched —
+// including any later `only` that is part of a column name or predicate.
+#[test]
+fn test_get_script_leaves_plain_index_unchanged() {
+    let index = create_simple_index();
+    assert_eq!(
+        index.get_script(),
+        "CREATE INDEX idx_orders_date ON app.orders USING btree (created_at);\n\n"
+    );
+}
+
+#[test]
+fn test_get_script_does_not_strip_only_outside_on_target() {
+    // `only_flag` appears after the ON target; it must survive verbatim.
+    let index = TableIndex {
+        schema: "public".to_string(),
+        table: "t".to_string(),
+        name: "ix".to_string(),
+        catalog: None,
+        indexdef: "CREATE INDEX ix ON public.t USING btree (only_flag)".to_string(),
+        is_partition_index: false,
+        comment: None,
+    };
+    assert_eq!(
+        index.get_script(),
+        "CREATE INDEX ix ON public.t USING btree (only_flag);\n\n"
+    );
+}
+
 #[test]
 fn test_get_script_case_conversion() {
     let index = TableIndex {

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -98,6 +98,7 @@ These schemas are designed to test comparison capabilities for the following Pos
 - **Modified**: `idx_audit_logs_table_op_changed_at` — unique index gains `record_id` column
 - **Removed**: all indexes on removed tables (`orders`, `order_items`)
 - **Unchanged**: existing indexes on `users`, `products`, `audit_logs`, `logs`
+- **Index on a partitioned parent** (Issue #223): `idx_partidx_value` is added to the existing partitioned parent `partidx` (two partitions, identical in both schemas). `pg_get_indexdef` renders such an index with `ON ONLY`, which builds only the invalid metadata index on the parent. The default (non-production) output must emit a plain `CREATE INDEX ... ON` so PostgreSQL builds and attaches every partition's index and the parent is valid immediately. The round-2 diff cannot catch this on its own — an invalid-but-present index still round-trips empty — so the integration job additionally asserts that no index is left `indisvalid = false` after applying the migration
 
 ### 7. Foreign Keys
 - **Added**: FKs on `reviews` (to products, users), FK on `user_preferences` (to users)

--- a/data/test/schema_a.sql
+++ b/data/test/schema_a.sql
@@ -1766,3 +1766,27 @@ CREATE TABLE test_schema.notnull_recreate (
     nn_col   varchar(10) NOT NULL,
     null_col varchar(10)
 );
+
+-- =============================================================================
+-- Regression: index on a partitioned parent must be created valid (#223)
+-- =============================================================================
+-- pg_get_indexdef renders a partitioned parent's index with `ON ONLY`, which builds
+-- only the metadata index on the parent and leaves it indisvalid=false until each
+-- partition's index is attached. The default (non-production) output has no attach
+-- step, so it must emit a plain `CREATE INDEX ... ON` — PostgreSQL then builds and
+-- attaches the partition indexes itself. The parent table is identical in both
+-- schemas; only the index is added in TO. (The round-2 diff cannot catch this on its
+-- own — an invalid index still round-trips empty — so the integration job also
+-- asserts indisvalid after applying the migration.)
+--
+-- FROM: partitioned table with two partitions, no index on partidx_value.
+CREATE TABLE test_schema.partidx (
+    id      integer,
+    value   text,
+    bucket  date
+) PARTITION BY RANGE (bucket);
+
+CREATE TABLE test_schema.partidx_2024 PARTITION OF test_schema.partidx
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+CREATE TABLE test_schema.partidx_2025 PARTITION OF test_schema.partidx
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');

--- a/data/test/schema_b.sql
+++ b/data/test/schema_b.sql
@@ -2030,3 +2030,21 @@ CREATE TABLE test_schema.notnull_recreate (
     id       integer,
     null_col varchar(10) NOT NULL
 );
+
+-- =============================================================================
+-- Regression: index on a partitioned parent must be created valid (#223)
+-- =============================================================================
+-- See schema_a.sql. Here the partitioned parent gains an index; the generated
+-- CREATE INDEX must be a plain `ON` (not `ON ONLY`) so the applied index is valid.
+CREATE TABLE test_schema.partidx (
+    id      integer,
+    value   text,
+    bucket  date
+) PARTITION BY RANGE (bucket);
+
+CREATE TABLE test_schema.partidx_2024 PARTITION OF test_schema.partidx
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+CREATE TABLE test_schema.partidx_2025 PARTITION OF test_schema.partidx
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+
+CREATE INDEX idx_partidx_value ON test_schema.partidx (value);


### PR DESCRIPTION
Closes #223 